### PR TITLE
Changes to correct canvas size and resizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,13 +67,10 @@ if(navigator.userAgent.match(/(opera|chrome|safari|firefox|msie)/i))
 
 $(document).ready(function() {
    $("#menu").height($(window).height());       // initial height
-   $("#viewer").height($(window).height());
 
    $(window).resize(function() {                // adjust the relevant divs
       $("#menu").height($(window).height());
       $("#menuHandle").css({top: '45%'});
-      $("#viewer").width($(window).width());
-      $("#viewer").height($(window).height());
    });
    setTimeout( function(){$('#menu').css('left','-280px');},3000); // -- hide slide-menu after 3secs
 
@@ -378,7 +375,7 @@ if(me=='web-online') {
 }
 </script>
 
-<div oncontextmenu="return false;" id="viewer"></div> <!-- avoiding popup when right mouse is clicked -->
+<div oncontextmenu="return false;" id="viewerContext"></div> <!-- avoiding popup when right mouse is clicked -->
 
 <div id="parametersdiv"></div>
 <div id="tail">
@@ -491,7 +488,7 @@ function onload() {
       };
    }
    
-   gProcessor = new OpenJsCad.Processor(document.getElementById("viewer"));
+   gProcessor = new OpenJsCad.Processor(document.getElementById("viewerContext"));
    setupDragDrop();
    //gProcessor.setDebugging(debugging); 
    if(me=='web-online') {    // we are online, fetch first example
@@ -662,7 +659,7 @@ function setupDragDrop() {
     throw new Error("Error: Your browser does not fully support the HTML File API");
   }
   var dropZone = document.getElementById('filedropzone');
-  //var dropZone = document.getElementById('viewer');
+  //var dropZone = document.getElementById('viewerContext');
   dropZone.addEventListener('dragover', function(evt) {
     evt.stopPropagation();
     evt.preventDefault();

--- a/openjscad.js
+++ b/openjscad.js
@@ -25,7 +25,7 @@ OpenJsCad.log = function(txt) {
 
 // A viewer is a WebGL canvas that lets the user view a mesh. The user can
 // tumble it around by dragging the mouse.
-OpenJsCad.Viewer = function(containerelement, width, height, initialdepth) {
+OpenJsCad.Viewer = function(containerelement, initialdepth) {
   var gl = GL.create();
   this.gl = gl;
   this.angleX = -60;
@@ -54,20 +54,20 @@ OpenJsCad.Viewer = function(containerelement, width, height, initialdepth) {
   this.lineOverlay = false;
 
   // Set up the viewport
-  gl.canvas.width = width;
-  gl.canvas.height = height;
-  gl.viewport(0, 0, width, height);
-  gl.matrixMode(gl.PROJECTION);
-  gl.loadIdentity();
-  gl.perspective(45, width / height, 0.5, 1000);
-  gl.matrixMode(gl.MODELVIEW);
+  this.gl.canvas.width  = $(containerelement).width();
+  this.gl.canvas.height = $(containerelement).height();
+  this.gl.viewport(0, 0, this.gl.canvas.width, this.gl.canvas.height);
+  this.gl.matrixMode(this.gl.PROJECTION);
+  this.gl.loadIdentity();
+  this.gl.perspective(45, this.gl.canvas.width / this.gl.canvas.height, 0.5, 1000);
+  this.gl.matrixMode(this.gl.MODELVIEW);
 
   // Set up WebGL state
-  gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
-  gl.clearColor(0.93, 0.93, 0.93, 1);
-  gl.enable(gl.DEPTH_TEST);
-  gl.enable(gl.CULL_FACE);
-  gl.polygonOffset(1, 1);
+  this.gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+  this.gl.clearColor(0.93, 0.93, 0.93, 1);
+  this.gl.enable(this.gl.DEPTH_TEST);
+  this.gl.enable(this.gl.CULL_FACE);
+  this.gl.polygonOffset(1, 1);
 
   // Black shader for wireframe
   this.blackShader = new GL.Shader('\
@@ -114,7 +114,7 @@ OpenJsCad.Viewer = function(containerelement, width, height, initialdepth) {
     <div class="arrow arrow-bottom" /></div>');
   this.touch.shiftControl = shiftControl;
 
-  $(containerelement).append(gl.canvas)
+  $(containerelement).append(this.gl.canvas)
     .append(shiftControl)
     .hammer({//touch screen control
       drag_lock_to_axis: true
@@ -170,20 +170,33 @@ OpenJsCad.Viewer = function(containerelement, width, height, initialdepth) {
       _this.touch.scale = 0;
     });
 
-  gl.onmousemove = function(e) {
+  this.gl.onmousemove = function(e) {
     _this.onMouseMove(e);
   };
-  gl.ondraw = function() {
+
+  this.gl.ondraw = function() {
     _this.onDraw();
   };
-  containerelement.onresize = function(e) {    // is not called
-     // var viewer = document.getElementById('viewer');
-     // fix distortion after resize of canvas
-     //gl.perspective(45, viewer.offsetWidth / viewer.offsetHeight, 0.5, 1000);
-     //_this.gl.perspective(45, containerelement.offsetWidth / containerelement.offsetHeight, 0.5, 1000);
-     alert("canvas has been resized");
+
+  this.gl.resizeCanvas = function() {
+    var canvasWidth  = _this.gl.canvas.clientWidth;
+    var canvasHeight = _this.gl.canvas.clientHeight;
+    if (_this.gl.canvas.width  != canvasWidth ||
+        _this.gl.canvas.height != canvasHeight) {
+      _this.gl.canvas.width  = canvasWidth;
+      _this.gl.canvas.height = canvasHeight;
+      _this.gl.viewport(0, 0, _this.gl.canvas.width, _this.gl.canvas.height);
+      _this.gl.matrixMode( _this.gl.PROJECTION );
+      _this.gl.loadIdentity();
+      _this.gl.perspective(45, _this.gl.canvas.width / _this.gl.canvas.height, 0.5, 1000 );
+      _this.gl.matrixMode( _this.gl.MODELVIEW );
+      _this.onDraw();
+    }
   };
-  gl.onmousewheel = function(e) {
+  // only window resize is available, so add an event callback for the canvas
+  window.addEventListener( 'resize', this.gl.resizeCanvas );
+
+  this.gl.onmousewheel = function(e) {
     var wheelDelta = 0;    
     if (e.wheelDelta) {
       wheelDelta = e.wheelDelta;
@@ -198,6 +211,7 @@ OpenJsCad.Viewer = function(containerelement, width, height, initialdepth) {
       _this.setZoom(coeff);
     }
   };
+
   this.clear();
 };
 
@@ -954,18 +968,14 @@ OpenJsCad.Processor.prototype = {
 */    
     var viewerdiv = document.createElement("div");
     viewerdiv.className = "viewer";
-    viewerdiv.style.width = '100%'; //this.viewerwidth; // + "px";
-    viewerdiv.style.height = '100%'; //this.viewerheight; // + "px";
-    viewerdiv.style.width = screen.width;
-    viewerdiv.style.height = screen.height;
-    //viewerdiv.style.overflow = 'hidden';
-    viewerdiv.style.backgroundColor = "rgb(200,200,200)";
+    viewerdiv.style.width = '100%';
+    viewerdiv.style.height = '100%';
     this.containerdiv.appendChild(viewerdiv);
     this.viewerdiv = viewerdiv;
     try {
       //this.viewer = new OpenJsCad.Viewer(this.viewerdiv, this.viewerwidth, this.viewerheight, this.initialViewerDistance);
       //this.viewer = new OpenJsCad.Viewer(this.viewerdiv, viewerdiv.offsetWidth, viewer.offsetHeight, this.initialViewerDistance);
-      this.viewer = new OpenJsCad.Viewer(this.viewerdiv, screen.width, screen.height, this.initialViewerDistance);
+      this.viewer = new OpenJsCad.Viewer(this.viewerdiv, this.initialViewerDistance);
     } catch(e) {
       //      this.viewer = null;
       this.viewerdiv.innerHTML = "<b><br><br>Error: " + e.toString() + "</b><br><br>OpenJsCad currently requires Google Chrome or Firefox with WebGL enabled";

--- a/style.css
+++ b/style.css
@@ -2,12 +2,19 @@
  * style.css for index.html of http://OpenJSCAD.org/
  */
 
-body { 
-   margin: 0px; 
-   padding: 0px; 
+html, body { 
+   margin: 0px; /* not inherited */
+   border: 0px none black; /* not inherited */
+   padding: 0px; /* not inherited */
    font-family: Helvetica, Arial, Sans;
 
-   /* viewer/canvas is screen.width x screen.height so when window 
+   /* these insure that the document uses the whole width and height of the browser */
+   min-height: 100%;
+   height: 100%;
+   min-width: 100%;
+   width: 100%;
+
+   /* viewer/canvas is full screen so when window 
       is resized all remains intact, but we make sure no scrollbar appears */
    overflow: hidden;       
 }
@@ -39,17 +46,30 @@ a:visited {
    background: rgba(255,255,255,0.15);
 }
 
-#viewer {
-   background: #fff;
-   //width: 100%;
-   //height: 100%;
+#viewerContext {
+   margin: 0px; /* not inherited */
+   border: 0px none black; /* not inherited */
+   padding: 0px; /* not inherited */
+
+   /* these insure that the canvas uses the whole width and height of the document */
+   background: blue;
+   height: 100%;
+   width: 100%;
+
    top: 0px;
    bottom: 0px;
 }
+
 canvas { 
+   margin: 0px; /* not inherited */
+   border: 0px none black; /* not inherited */
+   padding: 0px; /* not inherited */
+
+   /* these insure that the canvas uses the whole width and height of the document */
+   height: 100%;
+   width: 100%;
+
    cursor: move; 
-   padding: 0px; 
-   margin: 0px;
 }
 
 #about {


### PR DESCRIPTION
So, as the title says, I have made some changes to correct the size of the canvas, and added resizing of the canvas if the document size changes. The changes include:
- Changes to index.html to remove all hard coded height and width. These are now in style.css
- Changes to index.html to rename "viewer" div to "viewerContext". This corrected some confusion in style.css
- Changes to style.css to make the document 100% of the browser window. Add styles for HTML and BODY
- Changes to style.css to make "viewerContext" 100% of the BODY
- Changes to style.css to make "canvas" 100% of the viewerContext DIV
- Changes to openjscad.js to correct object references (gl... to this.gl...)
- Changes to openjscad.js to determine the size of the "viewer" div from the containerelement
- Changes to openjscad.js to add resizeCanvas() and an event callback from window resizes
- Changes to openjscad.js to cleanup code as screen width and height are no longer used

FYI, the styles for the viewer and the canvas can be changed now as well. Margins, borders, background colors, etc. should work normally. I think the canvas can be placed anywhere within a document, and formatted accordingly.

See http://153.142.230.27:7443/openjscad/index.html for a demo.