### PR TITLE
Contribution to CSG

### DIFF
--- a/csg.js
+++ b/csg.js
@@ -3697,7 +3697,7 @@ CSG.Matrix4x4.mirroring = function(plane) {
 		(1.0 - 2.0 * nx * nx), (-2.0 * ny * nx), (-2.0 * nz * nx), 0,
 		(-2.0 * nx * ny), (1.0 - 2.0 * ny * ny), (-2.0 * nz * ny), 0,
 		(-2.0 * nx * nz), (-2.0 * ny * nz), (1.0 - 2.0 * nz * nz), 0,
-		(-2.0 * nx * w), (-2.0 * ny * w), (-2.0 * nz * w), 1
+		( 2.0 * nx * w), ( 2.0 * ny * w), ( 2.0 * nz * w), 1
 	];
 	return new CSG.Matrix4x4(els);
 };

--- a/csg.js
+++ b/csg.js
@@ -5060,6 +5060,17 @@ CSG.addTransformationMethodsToPrototype = function(prot) {
 	prot.rotate = function(rotationCenter, rotationAxis, degrees) {
 		return this.transform(CSG.Matrix4x4.rotation(rotationCenter, rotationAxis, degrees));
 	};
+	
+	prot.rotateEulerAngles = function(alpha, beta, gamma, position) {
+        position = position || [0,0,0];
+		
+        var Rz1 = CSG.Matrix4x4.rotationZ(alpha);
+        var Rx  = CSG.Matrix4x4.rotationX(beta);
+        var Rz2 = CSG.Matrix4x4.rotationZ(gamma);
+        var T   = CSG.Matrix4x4.translation(new CSG.Vector3D(position));
+		
+		return this.transform(Rz2.multiply(Rx).multiply(Rz1).multiply(T));
+	};
 };
 
 //////////////////


### PR DESCRIPTION
Hi

There are two small changes in CSG.
1. Fixed  CSG.Matrix4x4.mirroring method. The minus sign in the last row of reflection matrix resulted in wrong reflection. For example code
```javascript
function main() {
    var MirrorNormal = [0,0,1];
    var MirrorPoint = [0,0,1];
    var plane = CSG.Plane.fromNormalAndPoint(MirrorNormal, MirrorPoint);
    var a = cube([5,2,1]);
    var b = a.mirrored(plane);
    return [a, b.setColor([1,1,0])];
}
```
resulted in geometry like on the picture
![img1](https://cloud.githubusercontent.com/assets/8076819/6450224/7af11bee-c137-11e4-96c4-8b59b6df985d.png)
whereas yellow box should be on top of the magenta one. This mirroring method is used in mirroredX, mirroredY, mirroredZ methods of CSG and CAG objects prototypes. But everywhere the origin point belongs to the mirroring plane and variable w = 0.
2. Added Euler rotation angles in ZXZ notation. It has been added to prototypes next to the other transformations.

Thanks
Vladimir