### PR TITLE
Partitioning of HTML from JavaScript in Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,79 +58,17 @@ Todo:
     <script src="ace/ace.js?0.3.1" charset="utf-8"></script>
     <script src="js/ui-drag-drop.js" charset="utf-8"></script>
     <script src="js/ui-editor.js" charset="utf-8"></script>
+    <script src="js/ui-cookies.js" charset="utf-8"></script>
+    <script src="js/ui-worker.js" charset="utf-8"></script>
+    <script src="js/index.js" charset="utf-8"></script>
 
-    <script lang="JavaScript">
-      var me = document.location.toString().match(/^file:/)?'web-offline':'web-online'; // me: {cli, web-offline, web-online}
-      var browser = 'unknown';
-      var showEditor = true;
-      var remoteUrl = './remote.pl?url=';
-      if(navigator.userAgent.match(/(opera|chrome|safari|firefox|msie)/i))
-        browser = RegExp.$1.toLowerCase();
-
-      $(document).ready(function() {
-          $("#menu").height($(window).height());       // initial height
-
-          $(window).resize(function() {                // adjust the relevant divs
-              $("#menu").height($(window).height());
-              $("#menuHandle").css({top: '45%'});
-            });
-          setTimeout( function(){$('#menu').css('left','-280px');},3000); // -- hide slide-menu after 3secs
-
-          $('#menu').mouseleave(function() {
-              $('#examples').css('height',0); $('#examples').hide();
-              $('#options').css('height',0); $('#options').hide();
-            });
-
-        // -- Examples
-          $('#examplesTitle').click(function() {
-              $('#examples').css('height','auto');
-              $('#examples').show();
-              $('#options').css('height',0);
-              $('#options').hide();
-            });
-          $('#examples').mouseleave(function() {
-              $('#examples').css('height',0);
-              $('#examples').hide();
-            });
-
-        // -- Options
-          $('#optionsTitle').click(function() {
-              $('#options').css('height','auto');
-              $('#options').show();
-              $('#examples').css('height',0);
-              $('#examples').hide();
-            });
-          $('#options').mouseleave(function() {
-              $('#options').css('height',0);
-              $('#options').hide();
-            });
-          getOptions();
-
-          //$('#optionsForm').submit(function() {
-          //   // save to cookie
-          //   $('#optionsForm').hide();
-          //   return false;
-          //});
-          $('#optionsForm').change(function() {
-            // save to cookie
-              saveOptions();
-            });
-
-          $('#plate').change(function() {
-              if($('#plate').val()=='custom') {
-                $('#customPlate').show();
-              } else {
-                $('#customPlate').hide();
-              }
-            });
-        });
-    </script>
-
+<!-- top left header (logo and error message) -->
     <div id="header">
       <img src="imgs/title.png">
       <div id="errordiv"></div>
     </div>
 
+<!-- sliding tab (help, links, examples, options, etc) -->
     <div id="menu">
       <img id="menuHandle" src="imgs/menuHandleVL.png">
       <nav>
@@ -159,10 +97,10 @@ Todo:
         <div id="examples"></div>
         <span class="menuSubInfo">Dozens of examples to learn from</span>
         <p/>
-        <!--<div id="optionsTitle" class="navlink"><a href='#' onclick='return false'>Options</a></div>
-        <div id="options">...</div>
+        <div id="optionsTitle" class="navlink"><a href='#' onclick='return false'>Options</a></div>
+        <div id="options"></div>
         <span class="menuSubInfo">Your personal settings</span></p>
-        <p/>-->
+        <p/>
         <b>Supported Formats</b>
         <table class="info">
           <tr><td align="right"><b>jscad</b></td><td><a target="_blank" href="https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide">OpenJSCAD</a> (native, import/export)</td></tr>
@@ -174,6 +112,7 @@ Todo:
       </nav>
     </div> <!-- /menu -->
 
+<!-- about dialog -->
     <div id="about">
       <img src="imgs/title.png">
       <br/>Version <script>document.write(OpenJsCad.version);</script>
@@ -201,6 +140,7 @@ Get your copy/clone/fork from <a href="https://github.com/Spiritdude/OpenJSCAD.o
       </p>
     </div> <!-- about -->
 
+<!-- editor -->
     <div id="editor">
 // -- OpenJSCAD.org logo
 
@@ -218,188 +158,13 @@ function main() {
 }
     </div> <!-- editor -->
 
-<script>
-var ex = [
-{ file:'logo.jscad', title: 'OpenJSCAD.org Logo' },
-{ file:'logo.amf', title: 'OpenJSCAD.org Logo', type: 'AMF' },
-
-{ file:'example001.jscad', title: 'Sphere with cutouts', spacing: true },
-{ file:'example001.scad', title: 'Sphere with cutouts', type: 'OpenSCAD' },
-{ file:'example002.jscad', title: 'Cone with cutouts' },
-{ file:'example002.scad', title: 'Cone with cutouts', type: 'OpenSCAD' },
-{ file:'example003.jscad', title: 'Cube with cutouts' },
-{ file:'example003.scad', title: 'Cube with cutouts', type: 'OpenSCAD' },
-// { file:'example004.jscad', title: 'Cube minus sphere' },
-{ file:'example005.jscad', title: 'Pavillon' },
-// { file:'center.jscad', title: 'Centers of Primitives' },
-
-// { file:'bunch-cubes.jscad', title: 'Bunch of Cubes', new: true },
-{ file:'lookup.jscad', title: 'Lookup()', spacing: true },
-{ file:'expand.jscad', title: 'Expand()' },
-{ file:'rectangular_extrude.jscad', title: 'Rectangular_extrude()' },
-{ file:'linear_extrude.jscad', title: 'Linear_extrude()' },
-{ file:'rotate_extrude.jscad', title: 'Rotate_extrude()' },
-{ file:'polyhedron.jscad', title: 'Polyhedron()' },
-{ file:'hull.jscad', title: 'Hull()' },
-{ file:'chain_hull.jscad', title: 'Chain_hull()' },
-{ file:'torus.jscad', title: 'Torus()' },
-
-{ file:'text.jscad', title: 'Vector_text()', spacing: true },
-
-{ file:'transparency.jscad', title: 'Transparency', spacing: true },
-{ file:'transparency.amf', title: 'Transparency', type: 'AMF' },
-{ file:'transparency2.jscad', title: 'Transparency 2' },
-
-{ file:'slices/double-screw.jscad', title: 'SolidFromSlices(): Double Screw', spacing: true },
-{ file:'slices/four2three.jscad', title: 'SolidFromSlices(): 4 to 3' },
-{ file:'slices/four2three-round.jscad', title: 'SolidFromSlices(): 4 to 3 round' },
-{ file:'slices/spring.jscad', title: 'SolidFromSlices(): Spring' },
-{ file:'slices/tor.jscad', title: 'SolidFromSlices(): Tor (multi-color)' },
-{ file:'slices/rose.jscad', title: 'SolidFromSlices(): Rose Curve' },
-
-{ file:'servo.jscad', title: 'Interactive Params: Servo Motor', wrap: true },
-{ file:'gear.jscad', title: 'Interactive Params: Gear' },
-{ file:'s-hook.jscad', title: 'Interactive Params: S Hook' },
-{ file:'grille.jscad', title: 'Interactive Params: Grille' },
-{ file:'axis-coupler.jscad', title: 'Interactive Params: Axis Coupler' },
-{ file:'lamp-shade.jscad', title: 'Interactive Params: Lamp Shade' },
-{ file:'celtic-knot-ring.jscad', title: 'Interactive Params: Celtic Knot Ring' },
-{ file:'stepper-motor.jscad', title: 'Interactive Params: Stepper Motor' },
-{ file:'iphone4-case.jscad', title: 'Interactive Params: iPhone4 Case' },
-{ file:'name_plate.jscad', title: 'Interactive Params: Name Plate' },
-{ file:'balloons.jscad', title: 'Interactive Params: Balloons', new: true },
-{ file:'globe.jscad', title: 'Globe' },
-
-{ file:'platonics/', title: 'Recursive Include(): Platonics', spacing: true },
-
-{ file:'3d_sculpture-VernonBussler.stl', title: '3D Model: 3D Sculpture (Vernon Bussler)', type: 'STL', spacing: true },
-{ file:'frog-OwenCollins.stl', title: '3D Model: Frog (Owen Collins)', type: 'STL' },
-{ file:'thing_7-Zomboe.stl', title: '3D Model: Thing 7 / Flower (Zomboe)', type: 'STL' },
-// { file:'organic_flower-Bogoboy23.stl', title: '3D Model: Organic Flower (Bogoboy23)', type: 'STL' }, // all wrong normals!!
-{ file:'yoda-RichRap.stl', title: '3D Model: Yoda (RichRap)', type: 'STL' },
-// { url:'http://pastebin.com/raw.php?i=wJLctyAQ', title: 'OpenJSCAD.org Logo', type:'Remote JSCAD' }
-// { file:'treefrog-Jerrill.stl', title: '3D Model: Treefrog (Jerrill)', type: 'STL' },    // nice frog, yet slow
-// { file:'klein_bottle-DizingOf.stl', title: '3D Model: Klein Bottle (DizingOf)', type: 'STL' } // too slow, over 400k triangles, huge memory consumption
-];
-if(me=='web-online') {
-   var wrap = 26;
-   var colp = 100/Math.floor(ex.length/wrap+1)+"%";
-   var src = '<table width=100%><tr><td widthx="+colp+" valign=top>';
-   //src += "<img id=examplesHandle src=\"imgs/menuHandleHU.png\">";
-   //src += '<b>Examples:</b>';
-   for(var i=0; i<ex.length; i++) {
-      if(ex[i].wrap) {
-         src += "</td><td class=examplesSeparator widthx="+colp+" valign=top>";
-      }
-      if(ex[i].spacing) src += "<p/>";
-      src += "<li><a href='#' onclick='fetchExample(\"examples/"+ex[i].file+"\"); return false;'>"+ex[i].title+"</a>\n";
-      if(ex[i].type) src += " <span class=type>("+ex[i].type+")</span></a>";
-      if(ex[i].new) src += " <span class=newExample>new</span></a>";
-      //src += "<li><a href='examples/"+ex[i].file+"\'>"+ex[i].title+"</a>\n";
-   }
-   src += "</td></tr></table>";
-   $('#examples').html(src);
-} else {
-   // examples off-line won't work yet as XHR is used
-   $('#examples').html("You are offline, drag'n'drop the examples from your installation");
-}
-
-{
-   var options = [ 'renderCode', 'author', 'license' ];
-   var metakeys = [ 'author', 'license' ];
-   saveOptions = function() {
-      for(var k in options) {
-         k = options[k];
-         //echo("setting "+k);
-         setCookie(k,$('#'+k).val());
-         if(metakeys[k]) metadata[k] = options[k];
-      }
-   }
-   getOptions = function() {
-      for(var k in options) {
-         k = options[k];
-         //echo("getting "+k);
-         if(getCookie(k)) $('#'+k).val(getCookie(k))
-      }
-   }
-
-   var src = '';
-   src += "<form id=optionsForm onsubmit='saveOptions(); return false'>";
-   src += "<div class=optionGroup><b>Your Identity / Full Name & Email</b><br/>";
-   src += "<input id=author type=text name=author size=30><div class=optionInfo>Applies when you export AMF (sets metadata)</div></div>";
-
-   var licenseOptions = {
-      "Public Domain": "Public Domain",
-      "CC BY": "Creative Commons CC BY",
-      "CC BY-ND": "Creative Commons CC BY-ND",
-      "CC BY-NC": "Creative Commons CC BY-NC",
-      "CC BY-SA": "Creative Commons CC BY-SA",
-      "CC BY-NC-SA": "Creative Commons CC BY-NC-SA",
-      "CC BY-NC-ND": "Creative Commons CC BY-NC-ND",
-      "MIT": "MIT License",
-      "GPLv2": "GPLv2",
-      "GPLv3": "GPLv3",
-      "Copyright": "Copyright",
-   };
-   src += "<div class=optionGroup><b>Default License</b><br/>";
-   src += "<select id=license name=license>";
-   for(var k in licenseOptions) {
-      src += "<option value='"+k+"'>"+licenseOptions[k];
-      src += "<br/>";
-   }
-   src += "</select><div class=optionInfo>Applies when you export AMF (sets metadata)</div></div>\n";
-
-   if(0) {
-      var renderCodeOptions = {
-         shiftReturn: "SHIFT+RETURN",
-         auto: "Automatic"
-      };
-      src += "<div class=optionGroup><b>Render Code</b></br>";
-      src += "<select id=renderCode name=renderCode>";
-      for(var k in renderCodeOptions) {
-         src += "<option value='"+k+"'>"+renderCodeOptions[k];
-      }
-      src += "</select></div>";
-   }
-   if(1) {
-      var plateOptions = {
-         "200x200": "200mm x 200mm",
-         "150x150": "150mm x 150mm",
-         "100x100": "100mm x 100mm",
-         "custom": "Custom",
-         "none": "None",
-      };
-      src += "<div class=optionGroup><b>Plate</b></br>";
-      src += "<select id=plate name=plate>";
-      for(var k in plateOptions) {
-         src += "<option value='"+k+"'>"+plateOptions[k];
-      }
-      src += "</select><br/>";
-      src += "<div style='display: none' id=customPlate>Custom: <input type=text id=plateCustomX name=plateCustomX size=4 value='125'> x <input type=text id=plateCustomY name=plateCustomY size=4 value='125'> [mm]</div>";
-      src += "</div>";
-   }
-   if(1) {
-      var themeOptions = {
-         "bright": "Bright",
-         "dark": "Dark",
-      };
-      src += "<div class=optionGroup><b>Theme</b></br>";
-      src += "<select id=theme name=theme>";
-      for(var k in themeOptions) {
-         src += "<option value='"+k+"'>"+themeOptions[k];
-      }
-      src += "</select><br/>";
-      src += "</div>";
-   }
-
-   src += "</form>";
-   $('#options').html(src);
-}
-</script>
-
+<!-- design viewer -->
     <div oncontextmenu="return false;" id="viewerContext"></div> <!-- avoiding popup when right mouse is clicked -->
 
+<!-- design parameters -->
     <div id="parametersdiv"></div>
+
+<!-- design information (status message, download buttons, drag and drop area, etc) -->
     <div id="tail">
       <div id="statusdiv"></div>
       <div id="filedropzone">
@@ -422,248 +187,9 @@ if(me=='web-online') {
       </div>
     </div> <!-- tail -->
 
+<!-- footer (version, copyright) -->
     <div id="footer">
-OpenJSCAD.org <script>document.write(OpenJsCad.version);</script>, MIT License, get your own copy/clone/fork from <a target=_blank href="https://github.com/Spiritdude/OpenJSCAD.org">GitHub: OpenJSCAD</a>
+      OpenJSCAD.org <script>document.write(OpenJsCad.version);</script>, MIT License, get your own copy/clone/fork from <a target=_blank href="https://github.com/Spiritdude/OpenJSCAD.org">GitHub: OpenJSCAD</a>
     </div>
-
-<script id="conversionWorker" type="javascript/worker">
-// adapted from http://www.html5rocks.com/en/tutorials/workers/basics/
-
-self.onmessage = function(e) {      // Worker to import STL/OBJ as it can take quite some while for 1MB+ large STLs
-   var data = e.data;
-
-   if(data.url) {     // RANT: why do something simple, when it can be done complicate: Workers & importScripts() (guys!!)
-      var url = data.url;
-      url = url.replace(/#.*$/,'');    // -- just to be sure ...
-      url = url.replace(/\?.*$/,'');
-      var index = url.indexOf('index.html');
-      if(index!=-1) {
-         url = url.substring(0,index);
-      }
-      importScripts(url+'csg.js',url+'openjscad.js',url+'openscad.js');
-      var src, type;
-      data.filename.toLowerCase().match(/\.(stl|obj|amf|gcode)$/i);
-      type = RegExp.$1;
-      if(type=='obj') {
-         src = parseOBJ(data.source,data.filename);
-      } else if(type=='amf') {
-         src = parseAMF(data.source,data.filename);
-      } else if(type=='gcode') {
-         src = parseGCode(data.source,data.filename);
-      } else {
-         src = parseSTL(data.source,data.filename);
-      }
-      self.postMessage({ source: src, filename: data.filename, url: data.remote });
-   }
-};
-</script>
-
-<script>
-var gProcessor = null;
-
-var _includePath = './';
-
-$(document).ready(onload());
-
-function onload() {
-   gProcessor = new OpenJsCad.Processor(document.getElementById("viewerContext"));
-   setUpEditor();
-   setupDragDrop();
-
-   //gProcessor.setDebugging(debugging);
-   if(me=='web-online') {    // we are online, fetch first example
-      docUrl = document.URL;
-      params = {};
-      docTitle = '';
-      if((!docUrl.match(/#(https?:\/\/\S+)$/)) && (!docUrl.match(/#(examples\/\S+)$/))) {
-         if(possibleParams = docUrl.split("&")) {
-            //console.log(possibleParams);
-            for (i = 0; i < possibleParams.length; ++i) {
-               //console.log("looping over: "+possibleParams[i]);
-                if(match = possibleParams[i].match(/^.*#?param\[([^\]]+)\]=(.*)$/i)) {
-                  //console.log("matched parameter: key="+decodeURIComponent(match[1])+", val="+decodeURIComponent(match[2])+"");
-                  params[decodeURIComponent(match[1])] = decodeURIComponent(match[2]);
-                }
-                else if(match = possibleParams[i].match(/^.*#?showEditor=false$/i)) {
-                  //console.log("not showing editor.");
-                  showEditor = false;
-                  $('#editor').hide();
-                }
-                else if(match = possibleParams[i].match(/^.*#?fetchUrl=(.*)$/i)) {
-                  //console.log("matched fetchUrl="+match[1]);
-                  urlParts = document.URL.match(/^([^#]+)#/);
-                  // derive an old-style URL for compatibility's sake
-                  docUrl = urlParts[1] + "#" + decodeURIComponent(match[1]);
-                }
-                else if(match = possibleParams[i].match(/^.*#?title=(.*)$/i)) {
-                  //console.log("matched title="+decodeURIComponent(match[1]));
-                  docTitle = decodeURIComponent(match[1]);
-                }
-            }
-            //console.log(params,docUrl,docTitle);
-         }
-      }
-      if(docUrl.match(/#(https?:\/\/\S+)$/)) {   // remote file referenced, e.g. http://openjscad.org/#http://somewhere/something.ext
-         var u = RegExp.$1;
-         var xhr = new XMLHttpRequest();
-         echo("fetching",u);
-         xhr.open("GET",remoteUrl+u,true);
-         if(u.match(/\.(stl|gcode)$/i)) {
-            xhr.overrideMimeType("text/plain; charset=x-user-defined");    // our pseudo binary retrieval (works with Chrome)
-         }
-         OpenJsCad.status("Fetching "+u+" <img id=busy src='imgs/busy.gif'>");
-         xhr.onload = function() {
-            //echo(this.responseText);
-            var data = JSON.parse(this.responseText);
-            //echo(data.url,data.filename,data.file);
-            fetchExample(data.file,data.url);
-            document.location = docUrl.replace(/#.*$/,'#');       // this won't reload the entire web-page
-         }
-         xhr.send();
-
-      } else if(docUrl.match(/#(examples\/\S+)$/)) {    // local example, e.g. http://openjscad.org/#examples/example001.jscad
-         var fn = RegExp.$1;
-         fetchExample(fn);
-         document.location = docUrl.replace(/#.*$/,'#');
-
-      } else {
-         fetchExample('examples/'+ex[0].file);
-      }
-  } else {
-    gProcessor.setJsCad(getSourceFromEditor());
-  }
-}
-
-function fetchExample(fn,url) {
-   gMemFs = [];
-
-   if(showEditor) { // FIXME test for the element
-      $('#editor').show();
-   } else {
-      $('#editor').hide();
-   }
-
-   if(fn.match(/\.[^\/]+$/)) {     // -- has extension
-      ;                                  // -- we could already check if valid extension (later)
-   } else {                              // -- folder referenced
-      if(!fn.match(/\/$/))
-         fn += "/";      // add tailing /
-      fn += 'main.jscad';
-   }
-
-   if(1) {     // doesn't work off-line yet
-      var xhr = new XMLHttpRequest();
-      xhr.open("GET", fn, true);
-      if(fn.match(/\.(stl|gcode)$/i)) {
-         xhr.overrideMimeType("text/plain; charset=x-user-defined");    // our pseudo binary retrieval (works with Chrome)
-      }
-      OpenJsCad.status("Loading "+fn+" <img id=busy src='imgs/busy.gif'>");
-      xhr.onload = function() {
-         var source = this.responseText;
-         var editorSource = source;
-         var asyncComputation = false;
-         var path = fn;
-
-         _includePath = path.replace(/\/[^\/]+$/,'/');
-
-         if(fn.match(/\.jscad$/i)||fn.match(/\.js$/i)) {
-            OpenJsCad.status("Processing "+fn+" <img id=busy src='imgs/busy.gif'>");
-            putSourceInEditor(editorSource,fn);
-            gProcessor.setJsCad(source,fn);
-
-         } else if(fn.match(/\.scad$/i)) {
-            OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
-            editorSource = source;
-            //if(url) editorSource = "// Remote retrieved <"+url+">\n"+editorSource;
-            if(!editorSource.match(/^\/\/!OpenSCAD/i)) {
-               editorSource = "//!OpenSCAD\n"+editorSource;
-            }
-            source = openscadOpenJscadParser.parse(editorSource);
-            if(0) {
-               source = "// OpenJSCAD.org: scad importer (openscad-openjscad-translator) '"+fn+"'\n\n"+source;
-            }
-            putSourceInEditor(editorSource,fn);
-            gProcessor.setJsCad(source,fn);
-
-         } else if(fn.match(/\.(stl|obj|amf|gcode)$/i)) {
-            OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
-            if(!fn.match(/\.amf/)) {
-               // import STL/OBJ/AMF via Worker() (async computation) as it takes quite some time
-               // RANT: the whole Blob() & Worker() is anything but a clean concept, mess over mess:
-               //       for example, to pass a DOM variable to worker via postMessage may create a circular reference
-               //       as the data is serialized, e.g. you cannot pass document and in the Worker access document.window.
-               //       Dear Google / JavaScript developers: don't make JS unuseable with this mess!
-               var blobURL = new Blob([document.querySelector('#conversionWorker').textContent]);
-               // -- the messy part coming here:
-               //var url = window.URL; url = url.replace(/#.*$/,''); url = url.createObjectURL(blobURL);
-               var worker = new Worker(window.webkitURL!==undefined?window.webkitURL.createObjectURL(blobURL):window.URL.createObjectURL(blobURL));
-               //var worker = new Worker(window.URL.createObjectURL(blobURL));
-               worker.onmessage = function(e) {    // worker finished
-                  var data = e.data;
-                  //echo("worker end:",data.source,data.filename);
-                  if(e.url) data.source = "// Remote retrieve <"+e.url+">\n"+data.source;
-                  putSourceInEditor(data.source,data.filename);
-                  gProcessor.setJsCad(data.source,data.filename);
-               };
-               var u = document.location.href;
-               u = u.replace(/#.*$/,'');
-               u = u.replace(/\?.*$/,'');
-               worker.postMessage({url: u, remote: url, source: source, filename: fn }); // start worker
-               asyncComputation = true;
-
-            } else {       // async (disabled)
-               OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
-               fn.match(/\.(stl|obj|amf|gcode)$/i);
-               var type = RegExp.$1;
-               if(type=='obj') {
-                  editorSource = source = parseOBJ(source,fn);
-               } else if(type=='amf') {
-                  editorSource = source = parseAMF(source,fn);
-               } else if(type=='gcode') {
-                  editorSource = source = parseGCode(source,fn);
-               } else {
-                  editorSource = source = parseSTL(source,fn);
-               }
-               putSourceInEditor(source,fn);
-            }
-            if(!asyncComputation) {
-               gProcessor.setJsCad(source,fn);
-            }
-         }
-      }
-      xhr.send();
-   }
-}
-
-// Show all exceptions to the user:
-OpenJsCad.AlertUserOfUncaughtExceptions();
-
-// ---------------------------------------------------------------------------------------------------------
-
-function setCookie(name, value, days) {
-    if (days) {
-        var date = new Date();
-        date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
-        var expires = "; expires=" + date.toGMTString();
-    } else var expires = "";
-    document.cookie = escape(name) + "=" + escape(value) + expires + "; path=/";
-}
-
-function getCookie(name) {
-    var nameEQ = escape(name) + "=";
-    var ca = document.cookie.split(';');
-    for (var i = 0; i < ca.length; i++) {
-        var c = ca[i];
-        while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-        if (c.indexOf(nameEQ) == 0) return unescape(c.substring(nameEQ.length, c.length));
-    }
-    return null;
-}
-
-function deleteCookie(name) {
-    createCookie(name, "", -1);
-}
-
-</script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
-<head>
+<html  xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
 <!-- 
 == OpenJSCAD.org, Copyright (c) 2013-2015 by Rene K. Mueller <spiritdude@gmail.com>, Licensed under MIT License ==
    with some code from OpenJsCad processfile.html by Joost Nieuwenhuijse 
@@ -37,134 +38,144 @@ Todo:
 - DONE: include(); support of multiple files, see http://jsfiddle.net/yybRu/
 
 -->
-  <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-  <title>OpenJSCAD.org</title>
-  <link rel="shortcut icon" href="imgs/favicon.png" type="image/x-png">
-  <link rel="stylesheet" href="jquery/themes/base/jquery-ui.css" />
-  <link rel="stylesheet" href="style.css" type="text/css">
-  <link rel="stylesheet" href="openjscad.css" type="text/css">
-</head>
-<body onload="onload()">
-  <script src="jquery/jquery-1.9.1.js"></script>
-  <script src="jquery/jquery-ui.js"></script>
-  <script src="jquery/jquery.hammer.js"></script>
-  <script src="lightgl.js"></script>
-  <script src="csg.js?0.3.1"></script>
-  <script src="formats.js?0.3.1"></script>
-  <script src="openjscad.js?0.3.1"></script>
-  <script src="openscad.js?0.3.1"></script>
-  <script src="underscore.js"></script>
-  <script src="openscad-openjscad-translator.js"></script>
-  <script src="ace/ace.js?0.3.1" charset="utf-8"></script>
+    <title>OpenJSCAD.org</title>
+    <link rel="shortcut icon" href="imgs/favicon.png" type="image/x-png">
+    <link rel="stylesheet" href="jquery/themes/base/jquery-ui.css" />
+    <link rel="stylesheet" href="style.css" type="text/css">
+    <link rel="stylesheet" href="openjscad.css" type="text/css">
+  </head>
+  <body>
+    <script src="jquery/jquery-1.9.1.js"></script>
+    <script src="jquery/jquery-ui.js"></script>
+    <script src="jquery/jquery.hammer.js"></script>
+    <script src="lightgl.js"></script>
+    <script src="csg.js?0.3.1"></script>
+    <script src="formats.js?0.3.1"></script>
+    <script src="openjscad.js?0.3.1"></script>
+    <script src="openscad.js?0.3.1"></script>
+    <script src="underscore.js"></script>
+    <script src="openscad-openjscad-translator.js"></script>
+    <script src="ace/ace.js?0.3.1" charset="utf-8"></script>
 
-<script lang=JavaScript>
-//$(function() { $("#parametersdiv").draggable(); }); // doesn't work well, disabled
-var me = document.location.toString().match(/^file:/)?'web-offline':'web-online'; // me: {cli, web-offline, web-online}
-var browser = 'unknown';
-var showEditor = true;
-var remoteUrl = './remote.pl?url=';
-if(navigator.userAgent.match(/(opera|chrome|safari|firefox|msie)/i))
-   browser = RegExp.$1.toLowerCase();
+    <script lang="JavaScript">
+      var me = document.location.toString().match(/^file:/)?'web-offline':'web-online'; // me: {cli, web-offline, web-online}
+      var browser = 'unknown';
+      var showEditor = true;
+      var remoteUrl = './remote.pl?url=';
+      if(navigator.userAgent.match(/(opera|chrome|safari|firefox|msie)/i))
+        browser = RegExp.$1.toLowerCase();
 
-$(document).ready(function() {
-   $("#menu").height($(window).height());       // initial height
+      $(document).ready(function() {
+          $("#menu").height($(window).height());       // initial height
 
-   $(window).resize(function() {                // adjust the relevant divs
-      $("#menu").height($(window).height());
-      $("#menuHandle").css({top: '45%'});
-   });
-   setTimeout( function(){$('#menu').css('left','-280px');},3000); // -- hide slide-menu after 3secs
+          $(window).resize(function() {                // adjust the relevant divs
+              $("#menu").height($(window).height());
+              $("#menuHandle").css({top: '45%'});
+            });
+          setTimeout( function(){$('#menu').css('left','-280px');},3000); // -- hide slide-menu after 3secs
 
-   $('#menu').mouseleave(function() {
-      $('#examples').css('height',0); $('#examples').hide(); 
-      $('#options').css('height',0); $('#options').hide(); 
-   });
+          $('#menu').mouseleave(function() {
+              $('#examples').css('height',0); $('#examples').hide();
+              $('#options').css('height',0); $('#options').hide();
+            });
 
-   // -- Examples
-   $('#examplesTitle').click(function() {
-      $('#examples').css('height','auto'); 
-      $('#examples').show(); 
-      $('#options').css('height',0); $('#options').hide(); 
-   });
-   $('#examples').mouseleave(function() {
-      $('#examples').css('height',0); $('#examples').hide(); 
-   });
+        // -- Examples
+          $('#examplesTitle').click(function() {
+              $('#examples').css('height','auto');
+              $('#examples').show();
+              $('#options').css('height',0);
+              $('#options').hide();
+            });
+          $('#examples').mouseleave(function() {
+              $('#examples').css('height',0);
+              $('#examples').hide();
+            });
 
-   // -- Options 
-   $('#optionsTitle').click(function() {
-      $('#options').css('height','auto'); $('#options').show(); 
-      $('#examples').css('height',0); $('#examples').hide(); 
-   });
-   $('#options').mouseleave(function() {
-      $('#options').css('height',0); $('#options').hide(); 
-   });
-   getOptions();
+        // -- Options 
+          $('#optionsTitle').click(function() {
+              $('#options').css('height','auto');
+              $('#options').show();
+              $('#examples').css('height',0);
+              $('#examples').hide();
+            });
+          $('#options').mouseleave(function() {
+              $('#options').css('height',0);
+              $('#options').hide();
+            });
+          getOptions();
 
-   //$('#optionsForm').submit(function() {
-   //   // save to cookie
-   //   $('#optionsForm').hide();
-   //   return false;
-   //});
-   $('#optionsForm').change(function() {
-      // save to cookie
-      saveOptions();
-   });
+          //$('#optionsForm').submit(function() {
+          //   // save to cookie
+          //   $('#optionsForm').hide();
+          //   return false;
+          //});
+          $('#optionsForm').change(function() {
+            // save to cookie
+              saveOptions();
+            });
    
-   $('#plate').change(function() {
-      if($('#plate').val()=='custom') {
-         $('#customPlate').show();
-      } else {
-         $('#customPlate').hide();
-      }
-   });
-});   
-</script>
-<div id="header">
-<img src="imgs/title.png">
-<div id="errordiv"></div>
-</div>
+          $('#plate').change(function() {
+              if($('#plate').val()=='custom') {
+                $('#customPlate').show();
+              } else {
+                $('#customPlate').hide();
+              }
+            });
+        });
+    </script>
 
-<div id=menu>
-<img id=menuHandle src="imgs/menuHandleVL.png">
-<nav>
-<div id=menuVersion>Version <script>document.write(OpenJsCad.version);</script></div>
-<p/>
-<table class=info>
-<tr><td align=right class=infoOperation>Render Code</td><td class=infoKey>SHIFT + RETURN</td></tr>
-<tr><td align=right class=infoOperation>Rotate XZ</td><td class=infoKey>Left Mouse</td></tr>
-<tr><td align=right class=infoOperation>Pan</td><td class=infoKey>Middle Mouse or SHIFT + Left Mouse</td></tr>
-<tr><td align=right class=infoOperation>Rotate XY</td><td class=infoKey>Right Mouse or ALT + Left Mouse</td></tr>
-<tr><td align=right class=infoOperation>Zoom In/Out</td><td class=infoKey>Wheel Mouse or CTRL + Left Mouse</td></tr>
-</table>
-<p><a class=navlink href="https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide" target=_blank>User Guide / Documentation <img src="imgs/externalLink.png" style=externalLink></a>
-<br/><span class=menuSubInfo>How to program with OpenJSCAD: online, offline & CLI</span></p>
-<p><a class=navlink href="https://plus.google.com/115007999023701819645" rel="publisher" target=_blank>Recent Updates <img src="imgs/externalLink.png" style=externalLink></a>
-<br/><span class=menuSubInfo>Announcements of recent developments</span></p>
-<p><a class=navlink href="https://plus.google.com/communities/114958480887231067224" target=_blank>Google+ Community <img src="imgs/externalLink.png" style=externalLink></a>
-<br/><span class=menuSubInfo>Discuss with other users &amp; developers</span></p>
-<div id=examplesTitle class=navlink><a href='#' onclick='return false'>Examples</a></div>
-<div id=examples></div>
-<span class=menuSubInfo>Dozens of examples to learn from</span></p>
-<p/>
-<!--<div id=optionsTitle class=navlink><a href='#' onclick='return false'>Options</a></div>
-<div id=options>...</div>
-<span class=menuSubInfo>Your personal settings</span></p>
-<p/>-->
-<b>Supported Formats</b>
-<table class=info>
-<tr><td align=right><b>jscad</b></td><td><a target=_blank href="https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide">OpenJSCAD</a> (native, import/export)</td></tr>
-<tr><td align=right><b>scad</b></td><td><a target=_blank href="http://openscad.org">OpenSCAD</a> (<a target=_blank href="https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide#direct-openscad-scad-import">experimental</a>, import)</td></tr>
-<tr><td align=right><b>stl</b></td><td><a target=_blank href="http://en.wikipedia.org/wiki/STL_(file_format)">STL format</a> (experimental, import/export)</td></tr>
-<tr><td align=right><b>amf</b></td><td><a target=_blank href="http://en.wikipedia.org/wiki/Additive_Manufacturing_File_Format">AMF format</a> (experimental, import/export)</td></tr>
-</table>
-<p><a class=navlink href="#" onclick="$('#about').show(); return false;">About</a></p>
-</nav>
-</div> <!-- /menu -->
+    <div id="header">
+      <img src="imgs/title.png">
+      <div id="errordiv"></div>
+    </div>
 
-<div id=about>
-<img src="imgs/title.png"><br>
-Version <script>document.write(OpenJsCad.version);</script>
-<p>
+    <div id="menu">
+      <img id="menuHandle" src="imgs/menuHandleVL.png">
+      <nav>
+        <div id="menuVersion">Version <script>document.write(OpenJsCad.version);</script></div>
+        <p/>
+        <table class="info">
+          <tr><td align="right" class="infoOperation">Render Code</td><td class="infoKey">SHIFT + RETURN</td></tr>
+          <tr><td align="right" class="infoOperation">Rotate XZ</td><td class="infoKey">Left Mouse</td></tr>
+          <tr><td align="right" class="infoOperation">Pan</td><td class="infoKey">Middle Mouse or SHIFT + Left Mouse</td></tr>
+          <tr><td align="right" class="infoOperation">Rotate XY</td><td class="infoKey">Right Mouse or ALT + Left Mouse</td></tr>
+          <tr><td align="right" class="infoOperation">Zoom In/Out</td><td class="infoKey">Wheel Mouse or CTRL + Left Mouse</td></tr>
+        </table>
+        <p>
+          <a class="navlink" href="https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide" target="_blank">User Guide / Documentation <img src="imgs/externalLink.png" style="externalLink"></a>
+          <br/><span class="menuSubInfo">How to program with OpenJSCAD: online, offline & CLI</span>
+        </p>
+        <p>
+          <a class="navlink" href="https://plus.google.com/115007999023701819645" rel="publisher" target="_blank">Recent Updates <img src="imgs/externalLink.png" style="externalLink"></a>
+          <br/><span class="menuSubInfo">Announcements of recent developments</span>
+        </p>
+        <p>
+          <a class="navlink" href="https://plus.google.com/communities/114958480887231067224" target="_blank">Google+ Community <img src="imgs/externalLink.png" style="externalLink"></a>
+          <br/><span class="menuSubInfo">Discuss with other users &amp; developers</span>
+        </p>
+        <div id="examplesTitle" class="navlink"><a href='#' onclick='return false'>Examples</a></div>
+        <div id="examples"></div>
+        <span class="menuSubInfo">Dozens of examples to learn from</span>
+        <p/>
+        <!--<div id="optionsTitle" class="navlink"><a href='#' onclick='return false'>Options</a></div>
+        <div id="options">...</div>
+        <span class="menuSubInfo">Your personal settings</span></p>
+        <p/>-->
+        <b>Supported Formats</b>
+        <table class="info">
+          <tr><td align="right"><b>jscad</b></td><td><a target="_blank" href="https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide">OpenJSCAD</a> (native, import/export)</td></tr>
+          <tr><td align="right"><b>scad</b></td><td><a target="_blank" href="http://openscad.org">OpenSCAD</a> (<a target=_blank href="https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide#direct-openscad-scad-import">experimental</a>, import)</td></tr>
+          <tr><td align="right"><b>stl</b></td><td><a target="_blank" href="http://en.wikipedia.org/wiki/STL_(file_format)">STL format</a> (experimental, import/export)</td></tr>
+          <tr><td align="right"><b>amf</b></td><td><a target="_blank" href="http://en.wikipedia.org/wiki/Additive_Manufacturing_File_Format">AMF format</a> (experimental, import/export)</td></tr>
+        </table>
+        <p><a class="navlink" href="#" onclick="$('#about').show(); return false;">About</a></p>
+      </nav>
+    </div> <!-- /menu -->
+
+    <div id="about">
+      <img src="imgs/title.png">
+      <br/>Version <script>document.write(OpenJsCad.version);</script>
+      <p>
 by 
 Joost Nieuwenhuijse (core), 
 Ren&eacute; K. M&uuml;ller (UI & CLI),
@@ -172,19 +183,24 @@ Stefan Baumann (core),
 Z3 Dev (CLI & GUI),
 Eduard Bespalov (core),
 Gary Hogdson (OpenSCAD translator)
-<p>csg.js core &amp; improvements by 
+      </p>
+      <p>csg.js core &amp; improvements by 
 Evan Wallace, 
 Eduard Bespalov, 
 Joost Nieuwenhuijse, 
 Alexandre Girard
-<p>
+      </p>
+      <p>
 License: MIT License<br>
 Get your copy/clone/fork from <a href="https://github.com/Spiritdude/OpenJSCAD.org" target=_blank>GitHub: OpenJSCAD</a>
-<p><br>
-<a class=okButton href='#' onclick="$('#about').hide(); return false;"> OK </a>
-</div>
+      </p>
+      <p>
+        <br/><a class="okButton" href='#' onclick="$('#about').hide(); return false;"> OK </a>
+      </p>
+    </div> <!-- about -->
 
-<div id="editor">// -- OpenJSCAD.org logo
+    <div id="editor">
+// -- OpenJSCAD.org logo
 
 function main() {
    return union(
@@ -198,10 +214,10 @@ function main() {
       )
    ).translate([0,0,1.5]).scale(10);
 }
-</div>
+    </div> <!-- editor -->
 
 <script>
-var ex = [ 
+var ex = [
 { file:'logo.jscad', title: 'OpenJSCAD.org Logo' },
 { file:'logo.amf', title: 'OpenJSCAD.org Logo', type: 'AMF' },
 
@@ -380,35 +396,36 @@ if(me=='web-online') {
 }
 </script>
 
-<div oncontextmenu="return false;" id="viewerContext"></div> <!-- avoiding popup when right mouse is clicked -->
+    <div oncontextmenu="return false;" id="viewerContext"></div> <!-- avoiding popup when right mouse is clicked -->
 
-<div id="parametersdiv"></div>
-<div id="tail">
-<div id="statusdiv"></div>
-<div id="filedropzone">
-  <div id="filedropzone_empty">
-  <script>document.write("Drop your jscad, scad, amf, stl file or multiple jscad files "+
+    <div id="parametersdiv"></div>
+    <div id="tail">
+      <div id="statusdiv"></div>
+      <div id="filedropzone">
+        <div id="filedropzone_empty">
+<script>document.write("Drop your jscad, scad, amf, stl file or multiple jscad files "+
      (browser=='chrome'&&me=='web-online'?"or folder with jscad files ":"")+
      " here (see <a style='font-weight: normal' href='https://github.com/Spiritdude/OpenJSCAD.org/wiki/User-Guide#support-of-include' target=_blank>details</a>) "+
      "<br>or edit OpenJSCAD or OpenSCAD source-code in built-in editor direct.");
-  </script></div>
-  <div id="filedropzone_filled">
-    <span id="currentfile">...</span>
-    <div id="filebuttons">
-      <button id="getstlbutton" style="display:none" onclick="getStl();">Get STL</button>
-      <button onclick="superviseAllFiles({forceReload:true});">Reload</button>
-      <!--button onclick="parseFile(gCurrentFile,true,false);">Debug (see below)</button-->
-	   <label for="autoreload">Auto Reload</label><input type="checkbox" name="autoreload" value="" id="autoreload" onclick="toggleAutoReload();">
-    </div>
-  </div>
-</div>
-</div>
-<div id=footer>
-OpenJSCAD.org 
-<script>document.write(OpenJsCad.version);</script>, MIT License, get your own copy/clone/fork from <a target=_blank href="https://github.com/Spiritdude/OpenJSCAD.org">GitHub: OpenJSCAD</a>
-</div>
+</script>
+       </div>
+       <div id="filedropzone_filled">
+         <span id="currentfile">...</span>
+         <div id="filebuttons">
+           <button id="getstlbutton" style="display:none" onclick="getStl();">Get STL</button>
+           <button onclick="superviseAllFiles({forceReload:true});">Reload</button>
+           <!--button onclick="parseFile(gCurrentFile,true,false);">Debug (see below)</button-->
+           <label for="autoreload">Auto Reload</label><input type="checkbox" name="autoreload" value="" id="autoreload" onclick="toggleAutoReload();">
+         </div>
+       </div>
+      </div>
+    </div> <!-- tail -->
 
-<script id=conversionWorker type="javascript/worker">
+    <div id="footer">
+OpenJSCAD.org <script>document.write(OpenJsCad.version);</script>, MIT License, get your own copy/clone/fork from <a target=_blank href="https://github.com/Spiritdude/OpenJSCAD.org">GitHub: OpenJSCAD</a>
+    </div>
+
+<script id="conversionWorker" type="javascript/worker">
 // adapted from http://www.html5rocks.com/en/tutorials/workers/basics/
 
 self.onmessage = function(e) {      // Worker to import STL/OBJ as it can take quite some while for 1MB+ large STLs
@@ -454,12 +471,15 @@ var gRootFs = [];             // root(s) of folders
 
 var _includePath = './';
 
+$(document).ready(onload());
+
 function onload() {
    gProcessor = new OpenJsCad.Processor(document.getElementById("viewerContext"));
 
    // -- http://ace.ajax.org/#nav=howto
    gEditor = ace.edit("editor");
    gEditor.setTheme("ace/theme/chrome");
+   gEditor.$blockScrolling = Infinity;
    //document.getElementById('ace_gutter').style.background = 'none';
    gEditor.getSession().setMode("ace/mode/javascript");
    //gEditor.getSession().on('change', function(e) { ; });               
@@ -490,7 +510,7 @@ function onload() {
    }
    
    setupDragDrop();
-   //gProcessor.setDebugging(debugging); 
+   //gProcessor.setDebugging(debugging);
    if(me=='web-online') {    // we are online, fetch first example
       //    gProcessor.setJsCad(gEditor.getValue());
       docUrl = document.URL;
@@ -540,7 +560,7 @@ function onload() {
             fetchExample(data.file,data.url);
             document.location = docUrl.replace(/#.*$/,'#');       // this won't reload the entire web-page
          }
-         xhr.send(); 
+         xhr.send();
  
       } else if(docUrl.match(/#(examples\/\S+)$/)) {    // local example, e.g. http://openjscad.org/#examples/example001.jscad
          var fn = RegExp.$1;
@@ -556,7 +576,8 @@ function onload() {
 }
 
 function fetchExample(fn,url) {
-   gMemFs = []; gCurrentFiles = [];
+   gMemFs = [];
+   gCurrentFiles = [];
    
    if(showEditor) {
       $('#editor').show();
@@ -644,13 +665,13 @@ function fetchExample(fn,url) {
                fn.match(/\.(stl|obj|amf|gcode)$/i);
                var type = RegExp.$1;
                if(type=='obj') {
-                  editorSource = source = parseOBJ(source,fn);   
+                  editorSource = source = parseOBJ(source,fn);
                } else if(type=='amf') {
-                  editorSource = source = parseAMF(source,fn);   
+                  editorSource = source = parseAMF(source,fn);
                } else if(type=='gcode') {
-                  editorSource = source = parseGCode(source,fn);   
+                  editorSource = source = parseGCode(source,fn);
                } else {
-                  editorSource = source = parseSTL(source,fn);   
+                  editorSource = source = parseSTL(source,fn);
                }
                //if(url) editorSource = source = "// Remote retrieved <"+url+">\n"+editorSource;
                putSourceInEditor(source,fn);
@@ -665,7 +686,7 @@ function fetchExample(fn,url) {
 }
 
 function putSourceInEditor(src,fn) {
-   gEditor.setValue(src); 
+   gEditor.setValue(src);
    gEditor.clearSelection();
    gEditor.navigateFileStart();
 
@@ -704,7 +725,8 @@ function setupDragDrop() {
 function handleFileSelect(evt) {
   evt.stopPropagation();
   evt.preventDefault();
-  gMemFs = []; gMainFile = null;
+  gMemFs = [];
+  gMainFile = null;
   if(!evt.dataTransfer) throw new Error("Not a datatransfer (1)");
   if(!evt.dataTransfer.files) throw new Error("Not a datatransfer (2)");
 
@@ -769,7 +791,7 @@ function loadLocalFiles() {               // this is the linear drag'n'drop, a l
   var items = gCurrentFiles;
   //console.log("loadLocalFiles",items);
   gMemFsCount = 0;
-  gMemFsTotal = items.length;      
+  gMemFsTotal = items.length;
   gMemFsChanged = 0;
   
   for(var i=0; i<items.length; i++) {
@@ -835,7 +857,7 @@ function readFileAsync(f) {                // RANT: JavaScript at its finest: 50
                  }
               }
            } else {
-             gMainFile = f;  
+             gMainFile = f;
            }
            if(gMemFsChanged>0) {
               if(!gMainFile)
@@ -848,7 +870,7 @@ function readFileAsync(f) {                // RANT: JavaScript at its finest: 50
      } else {
         throw new Error("Failed to read file");
         if(gProcessor) gProcessor.clearViewer();
-		  previousScript = null;
+  previousScript = null;
      }
   };
   if(f.name.match(/\.(stl|gcode)$/)) {
@@ -904,17 +926,17 @@ function superviseAllFiles(p) {           // check if there were changes: (re-)l
 var autoReloadTimer = null;
 
 function toggleAutoReload() {
-	if (document.getElementById("autoreload").checked) {
-		autoReloadTimer = setInterval(function(){
-		  //parseFile(gCurrentFile,false,true);
-		  superviseAllFiles();
+if (document.getElementById("autoreload").checked) {
+autoReloadTimer = setInterval(function(){
+  //parseFile(gCurrentFile,false,true);
+  superviseAllFiles();
     }, 1000);
-	} else {
-		if (autoReloadTimer !== null) {
-			clearInterval(autoReloadTimer);
-			autoReloadTimer = null;
-		}
-	}
+} else {
+if (autoReloadTimer !== null) {
+clearInterval(autoReloadTimer);
+autoReloadTimer = null;
+}
+}
 }
 
 var previousScript = null;
@@ -938,7 +960,7 @@ function parseFile(f, debugging, onlyifchanged) {     // here we convert the fil
     if(gProcessor && ((!onlyifchanged) || (previousScript !== source))) {
       var fn = gCurrentFile.name;
       fn = fn.replace(/^.*\/([^\/]*)$/,"$1");     // remove path, leave filename itself
-      gProcessor.setDebugging(debugging); 
+      gProcessor.setDebugging(debugging);
       //echo(gCurrentFile.lang);
       //gEditor.getSession().setMode("ace/mode/javascript");
       var asyncComputation = false;
@@ -954,7 +976,7 @@ function parseFile(f, debugging, onlyifchanged) {     // here we convert the fil
          if(0) {
             source = "// OpenJSCAD.org: scad importer (openscad-openjscad-translator) '"+fn+"'\n\n"+source;
          }
-         //gEditor.getSession().setMode("ace/mode/scad");  
+         //gEditor.getSession().setMode("ace/mode/scad");
          
       } else if(gCurrentFile.lang.match(/(stl|obj|amf|gcode)/i)) {
          OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
@@ -984,13 +1006,13 @@ function parseFile(f, debugging, onlyifchanged) {     // here we convert the fil
             fn.match(/\.(stl|obj|amf|gcode)$/i);
             var type = RegExp.$1;
             if(type=='obj') {
-               editorSource = source = parseOBJ(source,fn);   
+               editorSource = source = parseOBJ(source,fn);
             } else if(type=='amf') {
-               editorSource = source = parseAMF(source,fn);   
+               editorSource = source = parseAMF(source,fn);
             } else if(type=='gcode') {
-               editorSource = source = parseGCode(source,fn);   
+               editorSource = source = parseGCode(source,fn);
             } else {
-               editorSource = source = parseSTL(source,fn);   
+               editorSource = source = parseSTL(source,fn);
             }
          }
       } else {
@@ -1032,4 +1054,5 @@ function deleteCookie(name) {
 }
 
 </script>
-</body></html> 
+  </body>
+</html> 

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html  xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-<!-- 
+<!--
 == OpenJSCAD.org, Copyright (c) 2013-2015 by Rene K. Mueller <spiritdude@gmail.com>, Licensed under MIT License ==
-   with some code from OpenJsCad processfile.html by Joost Nieuwenhuijse 
+   with some code from OpenJsCad processfile.html by Joost Nieuwenhuijse
    in conjunction with csg.js, openjscad.js, lightgl.js by various authors (see them listed in the individual files)
 
-Purpose: 
+Purpose:
    More modern interface for OpenJsCad as published at http://joostn.github.com/OpenJsCad/
 
 History:
@@ -57,6 +57,7 @@ Todo:
     <script src="openscad-openjscad-translator.js"></script>
     <script src="ace/ace.js?0.3.1" charset="utf-8"></script>
     <script src="js/ui-drag-drop.js" charset="utf-8"></script>
+    <script src="js/ui-editor.js" charset="utf-8"></script>
 
     <script lang="JavaScript">
       var me = document.location.toString().match(/^file:/)?'web-offline':'web-online'; // me: {cli, web-offline, web-online}
@@ -92,7 +93,7 @@ Todo:
               $('#examples').hide();
             });
 
-        // -- Options 
+        // -- Options
           $('#optionsTitle').click(function() {
               $('#options').css('height','auto');
               $('#options').show();
@@ -114,7 +115,7 @@ Todo:
             // save to cookie
               saveOptions();
             });
-   
+
           $('#plate').change(function() {
               if($('#plate').val()=='custom') {
                 $('#customPlate').show();
@@ -177,18 +178,18 @@ Todo:
       <img src="imgs/title.png">
       <br/>Version <script>document.write(OpenJsCad.version);</script>
       <p>
-by 
-Joost Nieuwenhuijse (core), 
+by
+Joost Nieuwenhuijse (core),
 Ren&eacute; K. M&uuml;ller (UI & CLI),
 Stefan Baumann (core),
 Z3 Dev (CLI & GUI),
 Eduard Bespalov (core),
 Gary Hogdson (OpenSCAD translator)
       </p>
-      <p>csg.js core &amp; improvements by 
-Evan Wallace, 
-Eduard Bespalov, 
-Joost Nieuwenhuijse, 
+      <p>csg.js core &amp; improvements by
+Evan Wallace,
+Eduard Bespalov,
+Joost Nieuwenhuijse,
 Alexandre Girard
       </p>
       <p>
@@ -232,7 +233,7 @@ var ex = [
 { file:'example005.jscad', title: 'Pavillon' },
 // { file:'center.jscad', title: 'Centers of Primitives' },
 
-// { file:'bunch-cubes.jscad', title: 'Bunch of Cubes', new: true }, 
+// { file:'bunch-cubes.jscad', title: 'Bunch of Cubes', new: true },
 { file:'lookup.jscad', title: 'Lookup()', spacing: true },
 { file:'expand.jscad', title: 'Expand()' },
 { file:'rectangular_extrude.jscad', title: 'Rectangular_extrude()' },
@@ -272,12 +273,12 @@ var ex = [
 { file:'platonics/', title: 'Recursive Include(): Platonics', spacing: true },
 
 { file:'3d_sculpture-VernonBussler.stl', title: '3D Model: 3D Sculpture (Vernon Bussler)', type: 'STL', spacing: true },
-{ file:'frog-OwenCollins.stl', title: '3D Model: Frog (Owen Collins)', type: 'STL' },  
-{ file:'thing_7-Zomboe.stl', title: '3D Model: Thing 7 / Flower (Zomboe)', type: 'STL' },  
+{ file:'frog-OwenCollins.stl', title: '3D Model: Frog (Owen Collins)', type: 'STL' },
+{ file:'thing_7-Zomboe.stl', title: '3D Model: Thing 7 / Flower (Zomboe)', type: 'STL' },
 // { file:'organic_flower-Bogoboy23.stl', title: '3D Model: Organic Flower (Bogoboy23)', type: 'STL' }, // all wrong normals!!
 { file:'yoda-RichRap.stl', title: '3D Model: Yoda (RichRap)', type: 'STL' },
 // { url:'http://pastebin.com/raw.php?i=wJLctyAQ', title: 'OpenJSCAD.org Logo', type:'Remote JSCAD' }
-// { file:'treefrog-Jerrill.stl', title: '3D Model: Treefrog (Jerrill)', type: 'STL' },    // nice frog, yet slow 
+// { file:'treefrog-Jerrill.stl', title: '3D Model: Treefrog (Jerrill)', type: 'STL' },    // nice frog, yet slow
 // { file:'klein_bottle-DizingOf.stl', title: '3D Model: Klein Bottle (DizingOf)', type: 'STL' } // too slow, over 400k triangles, huge memory consumption
 ];
 if(me=='web-online') {
@@ -321,23 +322,23 @@ if(me=='web-online') {
          if(getCookie(k)) $('#'+k).val(getCookie(k))
       }
    }
-   
+
    var src = '';
    src += "<form id=optionsForm onsubmit='saveOptions(); return false'>";
    src += "<div class=optionGroup><b>Your Identity / Full Name & Email</b><br/>";
    src += "<input id=author type=text name=author size=30><div class=optionInfo>Applies when you export AMF (sets metadata)</div></div>";
 
    var licenseOptions = {
-      "Public Domain": "Public Domain", 
-      "CC BY": "Creative Commons CC BY", 
-      "CC BY-ND": "Creative Commons CC BY-ND", 
-      "CC BY-NC": "Creative Commons CC BY-NC", 
-      "CC BY-SA": "Creative Commons CC BY-SA", 
-      "CC BY-NC-SA": "Creative Commons CC BY-NC-SA", 
-      "CC BY-NC-ND": "Creative Commons CC BY-NC-ND", 
-      "MIT": "MIT License", 
-      "GPLv2": "GPLv2", 
-      "GPLv3": "GPLv3", 
+      "Public Domain": "Public Domain",
+      "CC BY": "Creative Commons CC BY",
+      "CC BY-ND": "Creative Commons CC BY-ND",
+      "CC BY-NC": "Creative Commons CC BY-NC",
+      "CC BY-SA": "Creative Commons CC BY-SA",
+      "CC BY-NC-SA": "Creative Commons CC BY-NC-SA",
+      "CC BY-NC-ND": "Creative Commons CC BY-NC-ND",
+      "MIT": "MIT License",
+      "GPLv2": "GPLv2",
+      "GPLv3": "GPLv3",
       "Copyright": "Copyright",
    };
    src += "<div class=optionGroup><b>Default License</b><br/>";
@@ -350,7 +351,7 @@ if(me=='web-online') {
 
    if(0) {
       var renderCodeOptions = {
-         shiftReturn: "SHIFT+RETURN", 
+         shiftReturn: "SHIFT+RETURN",
          auto: "Automatic"
       };
       src += "<div class=optionGroup><b>Render Code</b></br>";
@@ -376,7 +377,6 @@ if(me=='web-online') {
       src += "</select><br/>";
       src += "<div style='display: none' id=customPlate>Custom: <input type=text id=plateCustomX name=plateCustomX size=4 value='125'> x <input type=text id=plateCustomY name=plateCustomY size=4 value='125'> [mm]</div>";
       src += "</div>";
-      
    }
    if(1) {
       var themeOptions = {
@@ -391,7 +391,7 @@ if(me=='web-online') {
       src += "</select><br/>";
       src += "</div>";
    }
-   
+
    src += "</form>";
    $('#options').html(src);
 }
@@ -430,7 +430,7 @@ OpenJSCAD.org <script>document.write(OpenJsCad.version);</script>, MIT License, 
 // adapted from http://www.html5rocks.com/en/tutorials/workers/basics/
 
 self.onmessage = function(e) {      // Worker to import STL/OBJ as it can take quite some while for 1MB+ large STLs
-   var data = e.data; // JSON.parse(e.data);
+   var data = e.data;
 
    if(data.url) {     // RANT: why do something simple, when it can be done complicate: Workers & importScripts() (guys!!)
       var url = data.url;
@@ -459,9 +459,7 @@ self.onmessage = function(e) {      // Worker to import STL/OBJ as it can take q
 </script>
 
 <script>
-var gCurrentFile = null;
 var gProcessor = null;
-var gEditor = null;
 
 var _includePath = './';
 
@@ -469,44 +467,11 @@ $(document).ready(onload());
 
 function onload() {
    gProcessor = new OpenJsCad.Processor(document.getElementById("viewerContext"));
-
-   // -- http://ace.ajax.org/#nav=howto
-   gEditor = ace.edit("editor");
-   gEditor.setTheme("ace/theme/chrome");
-   gEditor.$blockScrolling = Infinity;
-   //document.getElementById('ace_gutter').style.background = 'none';
-   gEditor.getSession().setMode("ace/mode/javascript");
-   //gEditor.getSession().on('change', function(e) { ; });               
-
-   ['Shift-Return'].forEach(function(key) {
-      gEditor.commands.addCommand({
-         name: 'myCommand',
-         bindKey: { win: key, mac: key },
-         exec: function(editor) {
-            var src = editor.getValue();
-            if(src.match(/^\/\/\!OpenSCAD/i)) {
-               //editor.getSession().setMode("ace/mode/scad");
-               src = openscadOpenJscadParser.parse(src);
-            } else {
-               //editor.getSession().setMode("ace/mode/javascript");
-            }
-            gMemFs = [];
-            gProcessor.setJsCad(src);
-         },
-      });
-   });
-   if(0) {     // for reload when drag'n'dropped file(s) ([Reload] equivalent)
-      viewer.onkeypress = function(evt) {
-         if(evt.shiftKey&&evt.keyCode=='13') {   // Shift + Return
-            superviseFiles({forceReload:true});
-         }
-      };
-   }
-   
+   setUpEditor();
    setupDragDrop();
+
    //gProcessor.setDebugging(debugging);
    if(me=='web-online') {    // we are online, fetch first example
-      //    gProcessor.setJsCad(gEditor.getValue());
       docUrl = document.URL;
       params = {};
       docTitle = '';
@@ -555,34 +520,33 @@ function onload() {
             document.location = docUrl.replace(/#.*$/,'#');       // this won't reload the entire web-page
          }
          xhr.send();
- 
+
       } else if(docUrl.match(/#(examples\/\S+)$/)) {    // local example, e.g. http://openjscad.org/#examples/example001.jscad
          var fn = RegExp.$1;
          fetchExample(fn);
          document.location = docUrl.replace(/#.*$/,'#');
-         
+
       } else {
          fetchExample('examples/'+ex[0].file);
       }
-   } else {
-      gProcessor.setJsCad(gEditor.getValue());
-   }
+  } else {
+    gProcessor.setJsCad(getSourceFromEditor());
+  }
 }
 
 function fetchExample(fn,url) {
    gMemFs = [];
-   gCurrentFiles = [];
-   
-   if(showEditor) {
+
+   if(showEditor) { // FIXME test for the element
       $('#editor').show();
    } else {
       $('#editor').hide();
    }
-   
+
    if(fn.match(/\.[^\/]+$/)) {     // -- has extension
       ;                                  // -- we could already check if valid extension (later)
    } else {                              // -- folder referenced
-      if(!fn.match(/\/$/)) 
+      if(!fn.match(/\/$/))
          fn += "/";      // add tailing /
       fn += 'main.jscad';
    }
@@ -601,14 +565,12 @@ function fetchExample(fn,url) {
          var path = fn;
 
          _includePath = path.replace(/\/[^\/]+$/,'/');
-         
-         //gEditor.getSession().setMode("ace/mode/javascript");
+
          if(fn.match(/\.jscad$/i)||fn.match(/\.js$/i)) {
             OpenJsCad.status("Processing "+fn+" <img id=busy src='imgs/busy.gif'>");
-            //if(url) editorSource = "// Remote retrieved <"+url+">\n"+editorSource;
             putSourceInEditor(editorSource,fn);
             gProcessor.setJsCad(source,fn);
-            
+
          } else if(fn.match(/\.scad$/i)) {
             OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
             editorSource = source;
@@ -620,10 +582,9 @@ function fetchExample(fn,url) {
             if(0) {
                source = "// OpenJSCAD.org: scad importer (openscad-openjscad-translator) '"+fn+"'\n\n"+source;
             }
-            //gEditor.getSession().setMode("ace/mode/scad");
             putSourceInEditor(editorSource,fn);
             gProcessor.setJsCad(source,fn);
-            
+
          } else if(fn.match(/\.(stl|obj|amf|gcode)$/i)) {
             OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
             if(!fn.match(/\.amf/)) {
@@ -663,7 +624,6 @@ function fetchExample(fn,url) {
                } else {
                   editorSource = source = parseSTL(source,fn);
                }
-               //if(url) editorSource = source = "// Remote retrieved <"+url+">\n"+editorSource;
                putSourceInEditor(source,fn);
             }
             if(!asyncComputation) {
@@ -673,16 +633,6 @@ function fetchExample(fn,url) {
       }
       xhr.send();
    }
-}
-
-function putSourceInEditor(src,fn) {
-   gEditor.setValue(src);
-   gEditor.clearSelection();
-   gEditor.navigateFileStart();
-
-   previousFilename = fn;
-   previousScript = src;
-   gPreviousModificationTime = "";
 }
 
 // Show all exceptions to the user:
@@ -716,4 +666,4 @@ function deleteCookie(name) {
 
 </script>
   </body>
-</html> 
+</html>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@ Todo:
     <script src="underscore.js"></script>
     <script src="openscad-openjscad-translator.js"></script>
     <script src="ace/ace.js?0.3.1" charset="utf-8"></script>
+    <script src="js/ui-drag-drop.js" charset="utf-8"></script>
 
     <script lang="JavaScript">
       var me = document.location.toString().match(/^file:/)?'web-offline':'web-online'; // me: {cli, web-offline, web-online}
@@ -413,7 +414,7 @@ if(me=='web-online') {
          <span id="currentfile">...</span>
          <div id="filebuttons">
            <button id="getstlbutton" style="display:none" onclick="getStl();">Get STL</button>
-           <button onclick="superviseAllFiles({forceReload:true});">Reload</button>
+           <button onclick="reloadAllFiles();">Reload</button>
            <!--button onclick="parseFile(gCurrentFile,true,false);">Debug (see below)</button-->
            <label for="autoreload">Auto Reload</label><input type="checkbox" name="autoreload" value="" id="autoreload" onclick="toggleAutoReload();">
          </div>
@@ -461,13 +462,6 @@ self.onmessage = function(e) {      // Worker to import STL/OBJ as it can take q
 var gCurrentFile = null;
 var gProcessor = null;
 var gEditor = null;
-
-var gCurrentFiles = [];       // linear array, contains files (to read)
-var gMemFs = [];              // associated array, contains file content in source gMemFs[i].{name,source}
-var gMemFsCount = 0;          // async reading: count of already read files
-var gMemFsTotal = 0;          // async reading: total files to read (Count==Total => all files read)
-var gMemFsChanged = 0;        // how many files have changed
-var gRootFs = [];             // root(s) of folders 
 
 var _includePath = './';
 
@@ -593,10 +587,6 @@ function fetchExample(fn,url) {
       fn += 'main.jscad';
    }
 
-   //echo("checking gMemFs");
-   //if(gMemFs[fn]) {
-   //   console.log("found locally:",gMemFs[i].name);
-   //}
    if(1) {     // doesn't work off-line yet
       var xhr = new XMLHttpRequest();
       xhr.open("GET", fn, true);
@@ -695,337 +685,8 @@ function putSourceInEditor(src,fn) {
    gPreviousModificationTime = "";
 }
 
-// -----------------------------------------------------------------------------------------------------------
-// Drag'n'Drop Functionality
-// from old OpenJsCad processfile.html by Joost Nieuwenhuijse, 
-//     with changes by Rene K. Mueller
-// History:
-// 2013/04/02: massively upgraded to support multiple-files (chrome & firefox) and entire directory drag'n'drop (chrome only)
-
 // Show all exceptions to the user:
 OpenJsCad.AlertUserOfUncaughtExceptions();
-
-function setupDragDrop() {
-  // Check for the various File API support.
-  if (window.File && window.FileReader && window.FileList) {
-    // Great success! All the File APIs are supported.
-  } else {
-    throw new Error("Error: Your browser does not fully support the HTML File API");
-  }
-  var dropZone = document.getElementById('filedropzone');
-  //var dropZone = document.getElementById('viewerContext');
-  dropZone.addEventListener('dragover', function(evt) {
-    evt.stopPropagation();
-    evt.preventDefault();
-    evt.dataTransfer.dropEffect = 'copy';
-  }, false);
-  dropZone.addEventListener('drop', handleFileSelect, false);
-}
-
-function handleFileSelect(evt) {
-  evt.stopPropagation();
-  evt.preventDefault();
-  gMemFs = [];
-  gMainFile = null;
-  if(!evt.dataTransfer) throw new Error("Not a datatransfer (1)");
-  if(!evt.dataTransfer.files) throw new Error("Not a datatransfer (2)");
-
-  if(evt.dataTransfer.items&&evt.dataTransfer.items.length) {     // full directories, let's try
-    var items = evt.dataTransfer.items;
-    gCurrentFiles = [];
-    gMemFsCount = 0;
-    gMemFsTotal = 0;
-    gMemFsChanged = 0;
-    gRootFs = [];
-    for(var i=0; i<items.length; i++) {
-       //var item = items[i];//.webkitGetAsEntry();
-       //walkFileTree({file:items[i]});
-       walkFileTree(items[i].webkitGetAsEntry());
-       gRootFs.push(items[i].webkitGetAsEntry());
-    }
-  }
-  if(browser=='firefox'||me=='web-offline') {     // -- fallback, walkFileTree won't work with file://
-     if(evt.dataTransfer.files.length>0) {
-       gCurrentFiles = [];                              // -- be aware: gCurrentFiles = evt.dataTransfer.files won't work, as rewriting file will mess up the array
-       for(var i=0; i<evt.dataTransfer.files.length; i++) {
-         gCurrentFiles.push(evt.dataTransfer.files[i]);  // -- need to transfer the single elements
-       }
-       loadLocalFiles();
-     } else {
-       throw new Error("Please drop a single jscad, scad, stl file, or multiple jscad files");
-     }
-  }
-}
-
-function walkFileTree(item,path) {              // this is the core of the drag'n'drop:
-                                                //    1) walk the tree
-                                                //    2) read the files (readFileAsync)
-                                                //    3) re-render if there was a change (via readFileAsync)
-   path = path||"";
-   //console.log("item=",item);
-   if(item.isFile) {
-      item.file(function(file) {                // this is also asynchronous ... (making everything complicate)
-         if(file.name.match(/\.(jscad|js|scad|obj|stl|amf|gcode)$/)) {   // for now all files OpenJSCAD can handle
-            //console.log("walkFileTree File: "+path+item.name);
-            gMemFsTotal++;
-            gCurrentFiles.push(file);
-            readFileAsync(file);
-         }
-      });
-
-   } else if(item.isDirectory) {
-      var dirReader = item.createReader();
-      //console.log("walkFileTree Folder: "+item.name);
-      dirReader.readEntries(function(entries) {
-        // console.log("===",entries,entries.length);
-         for(var i=0; i<entries.length; i++) {
-            //console.log(i,entries[i]);
-            //walkFileTree({item:entries[i], path: path+item.name+"/"});
-            walkFileTree(entries[i],path+item.name+"/");
-         }
-      });
-   }
-}
-
-function loadLocalFiles() {               // this is the linear drag'n'drop, a list of files to read (when folders aren't supported)
-  var items = gCurrentFiles;
-  //console.log("loadLocalFiles",items);
-  gMemFsCount = 0;
-  gMemFsTotal = items.length;
-  gMemFsChanged = 0;
-  
-  for(var i=0; i<items.length; i++) {
-     var f = items[i];
-     //console.log(f);
-     readFileAsync(f);
-     //gMemFs[f.name] = f;
-  }
-}
-
-function setCurrentFile(file) {              // set one file (the one dragged) or main.jscad
-  gCurrentFile = file;
-  gPreviousModificationTime = "";
-
-  //console.log("execute: "+file.name);
-  if(file.name.match(/\.(jscad|js|scad|stl|obj|amf|gcode)$/i)) {
-    gCurrentFile.lang = RegExp.$1;
-  } else {
-    throw new Error("Please drop a file with .jscad, .scad or .stl extension");
-  }
-  if(file.size == 0) {
-    throw new Error("You have dropped an empty file");
-  }              
-  fileChanged(file);
-}     
-
-function readFileAsync(f) {                // RANT: JavaScript at its finest: 50 lines code to read a SINGLE file 
-  var reader = new FileReader();           //       this code looks complicate and it is complicate.
-
-  //console.log("request: "+f.name+" ("+f.fullPath+")");
-  reader.onloadend = function(evt) {
-     if(evt.target.readyState == FileReader.DONE) {
-        var source = evt.target.result;
-
-        //console.log("done reading: "+f.name,source?source.length:0);   // it could have been vanished while fetching (race condition)
-        gMemFsCount++;
-        
-        if(!gMemFs[f.name]||gMemFs[f.name].source!=source)     // note: assigning f.source = source too make gMemFs[].source the same, therefore as next
-          gMemFsChanged++;
-
-        f.source = source;                 // -- do it after comparing
-         
-        gMemFs[f.name] = f;                // -- we cache the file (and its actual content)
-
-        if(gMemFsCount==gMemFsTotal) {                // -- are we done reading all?
-           //console.log("all "+gMemFsTotal+" files read.");
-           if(gMemFsTotal>1||gMemFsCount>1) {         // we deal with multiple files, so we hide the editor to avoid confusion
-             $('#editor').hide();
-           } else {
-             $('#editor').show();
-           }
-           
-           if(gMemFsTotal>1) {
-              if(gMemFs['main.jscad']) {
-                 gMainFile = gMemFs['main.jscad'];
-              } else if(gMemFs['main.js']) {
-                 gMainFile = gMemFs['main.js'];
-              } else {
-                 for(var fn in gMemFs) {
-                   if(gMemFs[fn].name.match(/\/main.jscad$/)||gMemFs[fn].name.match(/\/main.js$/)) {
-                      gMainFile = gMemFs[fn];
-                   }
-                 }
-              }
-           } else {
-             gMainFile = f;
-           }
-           if(gMemFsChanged>0) {
-              if(!gMainFile)
-                throw("No main.jscad found");
-              //console.log("update & redraw "+gMainFile.name);
-              setCurrentFile(gMainFile);
-           }
-        }
-     
-     } else {
-        throw new Error("Failed to read file");
-        if(gProcessor) gProcessor.clearViewer();
-  previousScript = null;
-     }
-  };
-  if(f.name.match(/\.(stl|gcode)$/)) {
-     reader.readAsBinaryString(f,"UTF-8");
-  } else {
-     reader.readAsText(f,"UTF-8");
-  }
-}
-
-function fileChanged(f) {               // update the dropzone visual & call the main parser
-  var dropZone = document.getElementById('filedropzone');
-  gCurrentFile = f;
-  if(gCurrentFile) {
-    var txt;
-    if(gMemFsTotal>1) {
-       txt = "Current file: "+gCurrentFile.name+" (+ "+(gMemFsTotal-1)+" more files)";
-    } else {
-       txt = "Current file: "+gCurrentFile.name;
-    }
-    document.getElementById("currentfile").innerHTML = txt;
-    document.getElementById("filedropzone_filled").style.display = "block";
-    document.getElementById("filedropzone_empty").style.display = "none";
-  } else {
-    document.getElementById("filedropzone_filled").style.display = "none";
-    document.getElementById("filedropzone_empty").style.display = "block";
-  }
-  parseFile(f,false,false);
-}
-
-function superviseAllFiles(p) {           // check if there were changes: (re-)load all files and check if content was changed
-   //var f = gMainFile;                   // note: main functionality lies in readFileAsync()
-   //console.log("superviseAllFiles()");
-   
-   gMemFsCount = gMemFsTotal = 0;
-   gMemFsChanged = 0;
-   
-   if(p&&p.forceReload) 
-      gMemFsChanged++;
-   
-   if(!gRootFs||gRootFs.length==0||me=='web-offline') {              // walkFileTree won't work with file:// (regardless of chrome|firefox)
-     for(var i=0; i<gCurrentFiles.length; i++) {
-        //console.log("[offline] checking "+gCurrentFiles[i].name);
-        gMemFsTotal++;
-        readFileAsync(gCurrentFiles[i]);
-      }
-   } else {
-      for(var i=0; i<gRootFs.length; i++) {
-         walkFileTree(gRootFs[i]);
-      }
-   }
-}
-
-var autoReloadTimer = null;
-
-function toggleAutoReload() {
-if (document.getElementById("autoreload").checked) {
-autoReloadTimer = setInterval(function(){
-  //parseFile(gCurrentFile,false,true);
-  superviseAllFiles();
-    }, 1000);
-} else {
-if (autoReloadTimer !== null) {
-clearInterval(autoReloadTimer);
-autoReloadTimer = null;
-}
-}
-}
-
-var previousScript = null;
-
-function parseFile(f, debugging, onlyifchanged) {     // here we convert the file to a renderable source (jscad)
-  if(arguments.length==2) {
-    debugging = arguments[1];
-    onlyifchanged = arguments[2];
-    f = gCurrentFile;
-  }
-  //gCurrentFile = f;
-  var source = f.source;
-  var editorSource = source;
-  if(source == "") {
-    if(document.location.toString().match(/^file\:\//i)) {
-      throw new Error("Could not read file. You are using a local copy of OpenJSCAD.org; if you are using Chrome, you need to launch it with the following command line option:\n\n--allow-file-access-from-files\n\notherwise the browser will not have access to uploaded files due to security restrictions.");
-    } else {
-      throw new Error("Could not read file.");
-    }            
-  } else {         
-    if(gProcessor && ((!onlyifchanged) || (previousScript !== source))) {
-      var fn = gCurrentFile.name;
-      fn = fn.replace(/^.*\/([^\/]*)$/,"$1");     // remove path, leave filename itself
-      gProcessor.setDebugging(debugging);
-      //echo(gCurrentFile.lang);
-      //gEditor.getSession().setMode("ace/mode/javascript");
-      var asyncComputation = false;
-      
-      if(gCurrentFile.lang=='jscad'||gCurrentFile.lang=='js') {
-         ; // default
-      } else if(gCurrentFile.lang=='scad') {
-         editorSource = source;
-         if(!editorSource.match(/^\/\/!OpenSCAD/i)) {
-            editorSource = "//!OpenSCAD\n"+editorSource;
-         }
-         source = openscadOpenJscadParser.parse(editorSource);
-         if(0) {
-            source = "// OpenJSCAD.org: scad importer (openscad-openjscad-translator) '"+fn+"'\n\n"+source;
-         }
-         //gEditor.getSession().setMode("ace/mode/scad");
-         
-      } else if(gCurrentFile.lang.match(/(stl|obj|amf|gcode)/i)) {
-         OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
-         if(!fn.match(/amf/i)) {     // -- if you debug the STL parsing, change it to 'if(0&&...' so echo() works, otherwise in workers
-                                     //    echo() is not working.., and parseAMF requires jquery, which seem not working in workers
-            var blobURL = new Blob([document.querySelector('#conversionWorker').textContent]);
-            // -- the messy part coming here:
-            var worker = new Worker(window.webkitURL!==undefined?window.webkitURL.createObjectURL(blobURL):window.URL.createObjectURL(blobURL));
-            worker.onmessage = function(e) {
-               var data = e.data;
-               //echo("finished converting, source:",data.source);
-               if(data&&data.source&&data.source.length) {              // end of async conversion
-                  putSourceInEditor(data.source,data.filename);
-                  gMemFs[data.filename].source = data.source;
-                  gProcessor.setJsCad(data.source,data.filename);
-               } else {
-                  // worker responds gibberish (likely echo(), but format unknown)
-                  // echo("STL worker",data);
-               }
-            };
-            var u = document.location.href;
-            u = u.replace(/#.*$/,'');
-            u = u.replace(/\?.*$/,'');
-            worker.postMessage({url: u, source: source, filename: fn });
-            asyncComputation = true;
-         } else {
-            fn.match(/\.(stl|obj|amf|gcode)$/i);
-            var type = RegExp.$1;
-            if(type=='obj') {
-               editorSource = source = parseOBJ(source,fn);
-            } else if(type=='amf') {
-               editorSource = source = parseAMF(source,fn);
-            } else if(type=='gcode') {
-               editorSource = source = parseGCode(source,fn);
-            } else {
-               editorSource = source = parseSTL(source,fn);
-            }
-         }
-      } else {
-         throw new Error("Please drop a file with .jscad, .scad or .stl extension");
-      }
-      if(!asyncComputation) {                   // end of synchronous conversion
-         putSourceInEditor(editorSource,fn);
-         gMemFs[fn].source = source;
-         gProcessor.setJsCad(source,fn);
-      }
-    }
-  }
-}
 
 // ---------------------------------------------------------------------------------------------------------
 

--- a/js/index.js
+++ b/js/index.js
@@ -328,7 +328,7 @@ $(document).ready(function() {
         fetchExample('examples/'+ex[0].file);
       }
     } else {
-      gProcessor.setJsCad(getSourceFromEditor());
+      gProcessor.setJsCad(getSourceFromEditor(),"example.jscad");
     }
   });
 

--- a/js/index.js
+++ b/js/index.js
@@ -1,0 +1,386 @@
+// -----------------------------------------------------------------------------------------------------------
+// Page Specific Functionality: index.html
+
+// --- Dependencies
+// none
+
+// --- Global Variables
+
+// --- Global Functions
+
+var me = document.location.toString().match(/^file:/)?'web-offline':'web-online'; // me: {cli, web-offline, web-online}
+
+var browser = 'unknown';
+if(navigator.userAgent.match(/(opera|chrome|safari|firefox|msie)/i))
+  browser = RegExp.$1.toLowerCase();
+
+var showEditor = true;
+var remoteUrl = './remote.pl?url=';
+
+//console.log('me: ['+me+']');
+//console.log('browser: ['+browser+']');
+
+$(document).ready(function() {
+    createExamples();
+    createOptions();
+
+    $("#menu").height($(window).height());       // initial height
+
+    $(window).resize(function() {                // adjust the relevant divs
+        $("#menu").height($(window).height());
+        $("#menuHandle").css({top: '45%'});
+      });
+    setTimeout( function(){$('#menu').css('left','-280px');},3000); // -- hide slide-menu after 3secs
+
+    $('#menu').mouseleave(function() {
+        $('#examples').css('height',0); $('#examples').hide();
+        $('#options').css('height',0); $('#options').hide();
+      });
+
+  // -- Examples
+    $('#examplesTitle').click(function() {
+        $('#examples').css('height','auto');
+        $('#examples').show();
+        $('#options').css('height',0);
+        $('#options').hide();
+      });
+    $('#examples').mouseleave(function() {
+        $('#examples').css('height',0);
+        $('#examples').hide();
+      });
+
+  // -- Options
+    $('#optionsTitle').click(function() {
+        $('#options').css('height','auto');
+        $('#options').show();
+        $('#examples').css('height',0);
+        $('#examples').hide();
+      });
+    $('#options').mouseleave(function() {
+        $('#options').css('height',0);
+        $('#options').hide();
+      });
+    getOptions();
+
+    //$('#optionsForm').submit(function() {
+    //   // save to cookie
+    //   $('#optionsForm').hide();
+    //   return false;
+    //});
+    $('#optionsForm').change(function() {
+      // save to cookie
+        saveOptions();
+      });
+
+    $('#plate').change(function() {
+        if($('#plate').val()=='custom') {
+          $('#customPlate').show();
+        } else {
+          $('#customPlate').hide();
+        }
+      });
+  });
+
+var ex = [
+  { file:'logo.jscad', title: 'OpenJSCAD.org Logo' },
+  { file:'logo.amf', title: 'OpenJSCAD.org Logo', type: 'AMF' },
+
+  { file:'example001.jscad', title: 'Sphere with cutouts', spacing: true },
+  { file:'example001.scad', title: 'Sphere with cutouts', type: 'OpenSCAD' },
+  { file:'example002.jscad', title: 'Cone with cutouts' },
+  { file:'example002.scad', title: 'Cone with cutouts', type: 'OpenSCAD' },
+  { file:'example003.jscad', title: 'Cube with cutouts' },
+  { file:'example003.scad', title: 'Cube with cutouts', type: 'OpenSCAD' },
+  // { file:'example004.jscad', title: 'Cube minus sphere' },
+  { file:'example005.jscad', title: 'Pavillon' },
+  // { file:'center.jscad', title: 'Centers of Primitives' },
+
+  // { file:'bunch-cubes.jscad', title: 'Bunch of Cubes', new: true },
+  { file:'lookup.jscad', title: 'Lookup()', spacing: true },
+  { file:'expand.jscad', title: 'Expand()' },
+  { file:'rectangular_extrude.jscad', title: 'Rectangular_extrude()' },
+  { file:'linear_extrude.jscad', title: 'Linear_extrude()' },
+  { file:'rotate_extrude.jscad', title: 'Rotate_extrude()' },
+  { file:'polyhedron.jscad', title: 'Polyhedron()' },
+  { file:'hull.jscad', title: 'Hull()' },
+  { file:'chain_hull.jscad', title: 'Chain_hull()' },
+  { file:'torus.jscad', title: 'Torus()' },
+
+  { file:'text.jscad', title: 'Vector_text()', spacing: true },
+
+  { file:'transparency.jscad', title: 'Transparency', spacing: true },
+  { file:'transparency.amf', title: 'Transparency', type: 'AMF' },
+  { file:'transparency2.jscad', title: 'Transparency 2' },
+
+  { file:'slices/double-screw.jscad', title: 'SolidFromSlices(): Double Screw', spacing: true },
+  { file:'slices/four2three.jscad', title: 'SolidFromSlices(): 4 to 3' },
+  { file:'slices/four2three-round.jscad', title: 'SolidFromSlices(): 4 to 3 round' },
+  { file:'slices/spring.jscad', title: 'SolidFromSlices(): Spring' },
+  { file:'slices/tor.jscad', title: 'SolidFromSlices(): Tor (multi-color)' },
+  { file:'slices/rose.jscad', title: 'SolidFromSlices(): Rose Curve' },
+
+  { file:'servo.jscad', title: 'Interactive Params: Servo Motor', wrap: true },
+  { file:'gear.jscad', title: 'Interactive Params: Gear' },
+  { file:'s-hook.jscad', title: 'Interactive Params: S Hook' },
+  { file:'grille.jscad', title: 'Interactive Params: Grille' },
+  { file:'axis-coupler.jscad', title: 'Interactive Params: Axis Coupler' },
+  { file:'lamp-shade.jscad', title: 'Interactive Params: Lamp Shade' },
+  { file:'celtic-knot-ring.jscad', title: 'Interactive Params: Celtic Knot Ring' },
+  { file:'stepper-motor.jscad', title: 'Interactive Params: Stepper Motor' },
+  { file:'iphone4-case.jscad', title: 'Interactive Params: iPhone4 Case' },
+  { file:'name_plate.jscad', title: 'Interactive Params: Name Plate' },
+  { file:'balloons.jscad', title: 'Interactive Params: Balloons', new: true },
+  { file:'globe.jscad', title: 'Globe' },
+
+  { file:'platonics/', title: 'Recursive Include(): Platonics', spacing: true },
+
+  { file:'3d_sculpture-VernonBussler.stl', title: '3D Model: 3D Sculpture (Vernon Bussler)', type: 'STL', spacing: true },
+  { file:'frog-OwenCollins.stl', title: '3D Model: Frog (Owen Collins)', type: 'STL' },
+  { file:'thing_7-Zomboe.stl', title: '3D Model: Thing 7 / Flower (Zomboe)', type: 'STL' },
+  // { file:'organic_flower-Bogoboy23.stl', title: '3D Model: Organic Flower (Bogoboy23)', type: 'STL' }, // all wrong normals!!
+  { file:'yoda-RichRap.stl', title: '3D Model: Yoda (RichRap)', type: 'STL' },
+  // { url:'http://pastebin.com/raw.php?i=wJLctyAQ', title: 'OpenJSCAD.org Logo', type:'Remote JSCAD' }
+  // { file:'treefrog-Jerrill.stl', title: '3D Model: Treefrog (Jerrill)', type: 'STL' },    // nice frog, yet slow
+  // { file:'klein_bottle-DizingOf.stl', title: '3D Model: Klein Bottle (DizingOf)', type: 'STL' } // too slow, over 400k triangles, huge memory consumption
+];
+
+function createExamples() {
+  if(me=='web-online') {
+     var wrap = 26;
+     var colp = 100/Math.floor(ex.length/wrap+1)+"%";
+     var src = '<table width=100%><tr><td widthx='+colp+' valign=top>';
+     for(var i=0; i<ex.length; i++) {
+        if(ex[i].wrap) {
+           src += '</td><td class="examplesSeparator" widthx='+colp+' valign=top>';
+        }
+        if(ex[i].spacing) src += "<p/>";
+        src += "<li><a href='#' onclick='fetchExample(\"examples/"+ex[i].file+"\"); return false;'>"+ex[i].title+"</a>\n";
+        if(ex[i].type) src += " <span class=type>("+ex[i].type+")</span></a>";
+        if(ex[i].new) src += " <span class=newExample>new</span></a>";
+     }
+     src += "</td></tr></table>";
+     $('#examples').html(src);
+  } else {
+     // examples off-line won't work yet as XHR is used
+     $('#examples').html("You are offline, drag'n'drop the examples from your installation");
+  }
+};
+
+var options = [ 'renderCode', 'author', 'license' ];
+var metakeys = [ 'author', 'license' ];
+
+function saveOptions() {
+  for(var k in options) {
+    k = options[k];
+    setCookie(k,$('#'+k).val());
+    if(metakeys[k]) metadata[k] = options[k];
+  }
+};
+
+function getOptions() {
+  for(var k in options) {
+    k = options[k];
+    if(getCookie(k)) $('#'+k).val(getCookie(k))
+  }
+};
+
+function createOptions() {
+  var src = '';
+  src += "<form id=optionsForm onsubmit='saveOptions(); return false'>";
+  src += "<div class=optionGroup><b>Your Identity / Full Name & Email</b><br/>";
+  src += "<input id=author type=text name=author size=30><div class=optionInfo>Applies when you export AMF (sets metadata)</div></div>";
+
+  var licenseOptions = {
+      "Public Domain": "Public Domain",
+      "CC BY": "Creative Commons CC BY",
+      "CC BY-ND": "Creative Commons CC BY-ND",
+      "CC BY-NC": "Creative Commons CC BY-NC",
+      "CC BY-SA": "Creative Commons CC BY-SA",
+      "CC BY-NC-SA": "Creative Commons CC BY-NC-SA",
+      "CC BY-NC-ND": "Creative Commons CC BY-NC-ND",
+      "MIT": "MIT License",
+      "GPLv2": "GPLv2",
+      "GPLv3": "GPLv3",
+      "Copyright": "Copyright",
+    };
+  src += "<div class=optionGroup><b>Default License</b><br/>";
+  src += "<select id=license name=license>";
+  for(var k in licenseOptions) {
+    src += "<option value='"+k+"'>"+licenseOptions[k];
+    src += "<br/>";
+  }
+  src += "</select><div class=optionInfo>Applies when you export AMF (sets metadata)</div></div>\n";
+
+  if(0) {
+    var renderCodeOptions = {
+        shiftReturn: "SHIFT+RETURN",
+        auto: "Automatic"
+      };
+    src += "<div class=optionGroup><b>Render Code</b></br>";
+    src += "<select id=renderCode name=renderCode>";
+    for(var k in renderCodeOptions) {
+      src += "<option value='"+k+"'>"+renderCodeOptions[k];
+    }
+    src += "</select></div>";
+  }
+
+  if(1) {
+    var plateOptions = {
+        "200x200": "200mm x 200mm",
+        "150x150": "150mm x 150mm",
+        "100x100": "100mm x 100mm",
+        "custom": "Custom",
+        "none": "None",
+      };
+    src += "<div class=optionGroup><b>Plate</b></br>";
+    src += "<select id=plate name=plate>";
+    for(var k in plateOptions) {
+      src += "<option value='"+k+"'>"+plateOptions[k];
+    }
+    src += "</select><br/>";
+    src += "<div style='display: none' id=customPlate>Custom: <input type=text id=plateCustomX name=plateCustomX size=4 value='125'> x <input type=text id=plateCustomY name=plateCustomY size=4 value='125'> [mm]</div>";
+    src += "</div>";
+  }
+
+  if(1) {
+    var themeOptions = {
+        "bright": "Bright",
+        "dark": "Dark",
+      };
+    src += "<div class=optionGroup><b>Theme</b></br>";
+    src += "<select id=theme name=theme>";
+    for(var k in themeOptions) {
+      src += "<option value='"+k+"'>"+themeOptions[k];
+    }
+    src += "</select><br/>";
+    src += "</div>";
+  }
+
+  src += "</form>";
+  $('#options').html(src);
+};
+
+var gProcessor = null;
+
+var _includePath = './';
+
+$(document).ready(function() {
+    // Show all exceptions to the user:
+    OpenJsCad.AlertUserOfUncaughtExceptions();
+
+    gProcessor = new OpenJsCad.Processor(document.getElementById("viewerContext"));
+    setUpEditor();
+    setupDragDrop();
+
+    //gProcessor.setDebugging(debugging);
+    if(me=='web-online') {    // we are online, fetch first example
+      docUrl = document.URL;
+      params = {};
+      docTitle = '';
+      if((!docUrl.match(/#(https?:\/\/\S+)$/)) && (!docUrl.match(/#(examples\/\S+)$/))) {
+        if(possibleParams = docUrl.split("&")) {
+          //console.log(possibleParams);
+          for (i = 0; i < possibleParams.length; ++i) {
+            //console.log("looping over: "+possibleParams[i]);
+            if(match = possibleParams[i].match(/^.*#?param\[([^\]]+)\]=(.*)$/i)) {
+              //console.log("matched parameter: key="+decodeURIComponent(match[1])+", val="+decodeURIComponent(match[2])+"");
+              params[decodeURIComponent(match[1])] = decodeURIComponent(match[2]);
+            }
+            else if(match = possibleParams[i].match(/^.*#?showEditor=false$/i)) {
+              //console.log("not showing editor.");
+              showEditor = false;
+              $('#editor').hide();
+            }
+            else if(match = possibleParams[i].match(/^.*#?fetchUrl=(.*)$/i)) {
+              //console.log("matched fetchUrl="+match[1]);
+              urlParts = document.URL.match(/^([^#]+)#/);
+              // derive an old-style URL for compatibility's sake
+              docUrl = urlParts[1] + "#" + decodeURIComponent(match[1]);
+            }
+            else if(match = possibleParams[i].match(/^.*#?title=(.*)$/i)) {
+              //console.log("matched title="+decodeURIComponent(match[1]));
+              docTitle = decodeURIComponent(match[1]);
+            }
+          }
+          //console.log(params,docUrl,docTitle);
+        }
+      }
+      if(docUrl.match(/#(https?:\/\/\S+)$/)) {   // remote file referenced, e.g. http://openjscad.org/#http://somewhere/something.ext
+        var u = RegExp.$1;
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET",remoteUrl+u,true);
+        if(u.match(/\.(stl|gcode)$/i)) {
+          xhr.overrideMimeType("text/plain; charset=x-user-defined");    // our pseudo binary retrieval (works with Chrome)
+        }
+        OpenJsCad.status("Fetching "+u+" <img id=busy src='imgs/busy.gif'>");
+        xhr.onload = function() {
+          var data = JSON.parse(this.responseText);
+          fetchExample(data.file,data.url);
+          document.location = docUrl.replace(/#.*$/,'#');       // this won't reload the entire web-page
+        }
+        xhr.send();
+      }
+      else if(docUrl.match(/#(examples\/\S+)$/)) {    // local example, e.g. http://openjscad.org/#examples/example001.jscad
+        var fn = RegExp.$1;
+        fetchExample(fn);
+        document.location = docUrl.replace(/#.*$/,'#');
+      } else {
+        fetchExample('examples/'+ex[0].file);
+      }
+    } else {
+      gProcessor.setJsCad(getSourceFromEditor());
+    }
+  });
+
+function fetchExample(fn,url) {
+  gMemFs = [];
+
+  if(showEditor) { // FIXME test for the element
+    $('#editor').show();
+  } else {
+    $('#editor').hide();
+  }
+
+  if(fn.match(/\.[^\/]+$/)) {     // -- has extension
+    ;                                  // -- we could already check if valid extension (later)
+  } else {                              // -- folder referenced
+    if(!fn.match(/\/$/))
+      fn += "/";      // add tailing /
+    fn += 'main.jscad';
+  }
+
+  if(1) {     // doesn't work off-line yet
+    var xhr = new XMLHttpRequest();
+    xhr.open("GET", fn, true);
+    if(fn.match(/\.(stl|gcode)$/i)) {
+      xhr.overrideMimeType("text/plain; charset=x-user-defined");    // our pseudo binary retrieval (works with Chrome)
+    }
+    OpenJsCad.status("Loading "+fn+" <img id=busy src='imgs/busy.gif'>");
+    xhr.onload = function() {
+        var source = this.responseText;
+        var editorSource = source;
+        var path = fn;
+
+        _includePath = path.replace(/\/[^\/]+$/,'/');
+
+        var e = fn.toLowerCase().match(/\.(jscad|js|scad|stl|obj|amf|gcode)$/i);
+        e = RegExp.$1;
+        if(e == 'amf') {
+        // FIXME remove this branch once JQUERY is no longer needed for AMF
+          source = parseAMF(source,fn);
+          putSourceInEditor(source,fn);
+          gProcessor.setJsCad(source,fn);
+        } else {
+           OpenJsCad.status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
+           var worker = createConversionWorker();
+           var u = document.location.href;
+           u = u.replace(/#.*$/,'');
+           u = u.replace(/\?.*$/,'');
+        // NOTE: cache: false is set to allow evaluation of 'include' statements
+           worker.postMessage({url: u, source: source, filename: fn, cache: false});
+        }
+      };
+      xhr.send();
+  }
+};
+

--- a/js/ui-cookies.js
+++ b/js/ui-cookies.js
@@ -1,0 +1,35 @@
+// -----------------------------------------------------------------------------------------------------------
+// Cookie Functionality
+
+// --- Dependencies
+// none
+
+// --- Global Variables
+
+// --- Global Functions
+
+function setCookie(name, value, days) {
+  var expires = "";
+  if (days) {
+    var date = new Date();
+    date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+    expires = "; expires=" + date.toGMTString();
+  }
+  document.cookie = escape(name) + "=" + escape(value) + expires + "; path=/";
+}
+
+function getCookie(name) {
+  var nameEQ = escape(name) + "=";
+  var ca = document.cookie.split(';');
+  for (var i = 0; i < ca.length; i++) {
+    var c = ca[i];
+    while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+    if (c.indexOf(nameEQ) == 0) return unescape(c.substring(nameEQ.length, c.length));
+  }
+  return null;
+}
+
+function deleteCookie(name) {
+  setCookie(name, "", -1);
+}
+

--- a/js/ui-drag-drop.js
+++ b/js/ui-drag-drop.js
@@ -147,7 +147,6 @@ function loadLocalFiles() {
 // set one file (the one dragged) or main.jscad
 function setCurrentFile(file) {
   gCurrentFile = file;
-  gPreviousModificationTime = "";
 
   console.log("execute: "+file.name);
   if(file.name.match(/\.(jscad|js|scad|stl|obj|amf|gcode)$/i)) { // FIXME where is the list?

--- a/js/ui-drag-drop.js
+++ b/js/ui-drag-drop.js
@@ -1,0 +1,356 @@
+// -----------------------------------------------------------------------------------------------------------
+// Drag'n'Drop Functionality
+// from old OpenJsCad processfile.html by Joost Nieuwenhuijse, 
+//     with changes by Rene K. Mueller
+// History:
+// 2013/04/02: massively upgraded to support multiple-files (chrome & firefox) and entire directory drag'n'drop (chrome only)
+
+// --- Dependencies
+// * gProcessor var
+// * putSourceInEditor function
+// * #conversionWorker element with the worker code
+// * #filedropzone element
+// * #filedropzone_filled element
+// * #filedropzone_empty element
+// * #currentfile element
+
+// --- Global Variables
+var gCurrentFiles = [];       // linear array, contains files (to read)
+var gMemFs = [];              // associated array, contains file content in source gMemFs[i].{name,source}
+
+// --- Public API
+
+function setupDragDrop() {
+  // Check for the various File API support.
+  if (window.File && window.FileReader && window.FileList) {
+    // Great success! All the File APIs are supported.
+  } else {
+    throw new Error("Error: Your browser does not support the HTML File API");
+  }
+  var dropZone = document.getElementById('filedropzone');
+  dropZone.addEventListener('dragover', function(evt) {
+    evt.stopPropagation();
+    evt.preventDefault();
+    evt.dataTransfer.dropEffect = 'copy';
+  }, false);
+  dropZone.addEventListener('drop', handleFileSelect, false);
+}
+
+function reloadAllFiles() {
+  superviseAllFiles({forceReload:true});
+}
+
+function toggleAutoReload() {
+   if (document.getElementById("autoreload").checked) {
+      autoReloadTimer = setInterval(function(){
+        superviseAllFiles();
+    }, 1000);
+   } else {
+      if (autoReloadTimer !== null) {
+         clearInterval(autoReloadTimer);
+         autoReloadTimer = null;
+      }
+   }
+}
+
+// --- Private Variables
+var autoReloadTimer = null;
+
+var gCurrentFile = null;
+
+var gMemFsCount = 0;          // async reading: count of already read files
+var gMemFsTotal = 0;          // async reading: total files to read (Count==Total => all files read)
+var gMemFsChanged = 0;        // how many files have changed
+var gRootFs = [];             // root(s) of folders
+
+// --- Private API
+
+function handleFileSelect(evt) {
+  evt.stopPropagation();
+  evt.preventDefault();
+
+  if(!evt.dataTransfer) throw new Error("Event is not a datatransfer (1)");
+  if(!evt.dataTransfer.files) throw new Error("Event is not a datatransfer (2)");
+
+  gMemFs = []; gMainFile = null;
+
+  if(evt.dataTransfer.items && evt.dataTransfer.items.length) {     // full directories, let's try
+    var items = evt.dataTransfer.items;
+    gCurrentFiles = [];
+    gMemFsCount = 0;
+    gMemFsTotal = 0;
+    gMemFsChanged = 0;
+    gRootFs = [];
+    for(var i=0; i<items.length; i++) {
+       walkFileTree(items[i].webkitGetAsEntry());
+       gRootFs.push(items[i].webkitGetAsEntry());
+    }
+  }
+  if(browser=='firefox' || me=='web-offline') {     // -- fallback, walkFileTree won't work with file://
+     if(evt.dataTransfer.files.length>0) {
+       gCurrentFiles = [];                              // -- be aware: gCurrentFiles = evt.dataTransfer.files won't work, as rewriting file will mess up the array
+       for(var i=0; i<evt.dataTransfer.files.length; i++) {
+         gCurrentFiles.push(evt.dataTransfer.files[i]);  // -- need to transfer the single elements
+       }
+       loadLocalFiles();
+     } else {
+       throw new Error("Please drop a single jscad, scad, stl file, or multiple jscad files");
+     }
+  }
+}
+
+// this is the core of the drag'n'drop:
+//    1) walk the tree
+//    2) read the files (readFileAsync)
+//    3) re-render if there was a change (via readFileAsync)
+function walkFileTree(item,path) {
+   path = path||"";
+   //console.log("item=",item);
+   if(item.isFile) {
+      item.file(function(file) {                // this is also asynchronous ... (making everything complicate)
+         if(file.name.match(/\.(jscad|js|scad|obj|stl|amf|gcode)$/)) {   // FIXME now all files OpenJSCAD can handle
+            console.log("walkFileTree File: "+path+item.name);
+            gMemFsTotal++;
+            gCurrentFiles.push(file);
+            readFileAsync(file);
+         }
+      });
+
+   } else if(item.isDirectory) {
+      var dirReader = item.createReader();
+      console.log("walkFileTree Folder: "+item.name);
+      dirReader.readEntries(function(entries) {
+        // console.log("===",entries,entries.length);
+         for(var i=0; i<entries.length; i++) {
+            //console.log(i,entries[i]);
+            walkFileTree(entries[i],path+item.name+"/");
+         }
+      });
+   }
+}
+
+// this is the linear drag'n'drop, a list of files to read (when folders aren't supported)
+function loadLocalFiles() {
+  var items = gCurrentFiles;
+  console.log("loadLocalFiles",items);
+  gMemFsCount = 0;
+  gMemFsTotal = items.length;      
+  gMemFsChanged = 0;
+  
+  for(var i=0; i<items.length; i++) {
+     var f = items[i];
+     console.log(f);
+     readFileAsync(f);
+  }
+}
+
+// set one file (the one dragged) or main.jscad
+function setCurrentFile(file) {
+  gCurrentFile = file;
+  gPreviousModificationTime = "";
+
+  console.log("execute: "+file.name);
+  if(file.name.match(/\.(jscad|js|scad|stl|obj|amf|gcode)$/i)) { // FIXME where is the list?
+    gCurrentFile.lang = RegExp.$1;
+  } else {
+    throw new Error("Please drop a file with .jscad, .scad or .stl extension");
+  }
+  if(file.size == 0) {
+    throw new Error("You have dropped an empty file");
+  }              
+  fileChanged(file);
+}     
+
+// RANT: JavaScript at its finest: 50 lines code to read a SINGLE file 
+//       this code looks complicate and it is complicate.
+function readFileAsync(f) {
+  var reader = new FileReader();
+
+  console.log("request: "+f.name+" ("+f.fullPath+")");
+  reader.onloadend = function(evt) {
+     if(evt.target.readyState == FileReader.DONE) {
+        var source = evt.target.result;
+
+        console.log("done reading: "+f.name,source?source.length:0);   // it could have been vanished while fetching (race condition)
+        gMemFsCount++;
+        
+        if(!gMemFs[f.name]||gMemFs[f.name].source!=source)     // note: assigning f.source = source too make gMemFs[].source the same, therefore as next
+          gMemFsChanged++;
+
+        f.source = source;                 // -- do it after comparing
+         
+        gMemFs[f.name] = f;                // -- we cache the file (and its actual content)
+
+        if(gMemFsCount==gMemFsTotal) {                // -- are we done reading all?
+           console.log("all "+gMemFsTotal+" files read.");
+           if(gMemFsTotal>1||gMemFsCount>1) {         // we deal with multiple files, so we hide the editor to avoid confusion
+             $('#editor').hide();
+           } else {
+             $('#editor').show();
+           }
+           
+           if(gMemFsTotal>1) {
+              if(gMemFs['main.jscad']) {
+                 gMainFile = gMemFs['main.jscad'];
+              } else if(gMemFs['main.js']) {
+                 gMainFile = gMemFs['main.js'];
+              } else {
+                 for(var fn in gMemFs) {
+                   if(gMemFs[fn].name.match(/\/main.jscad$/)||gMemFs[fn].name.match(/\/main.js$/)) {
+                      gMainFile = gMemFs[fn];
+                   }
+                 }
+              }
+           } else {
+             gMainFile = f;  
+           }
+           if(gMemFsChanged>0) {
+              if(!gMainFile)
+                throw("No main.jscad found");
+              console.log("update & redraw "+gMainFile.name);
+              setCurrentFile(gMainFile);
+           }
+        }
+     
+     } else {
+        throw new Error("Failed to read file");
+        if(gProcessor) gProcessor.clearViewer();
+        previousScript = null;
+     }
+  };
+  if(f.name.match(/\.(stl|gcode)$/)) { // FIXME how to determine?
+     reader.readAsBinaryString(f,"UTF-8");
+  } else {
+     reader.readAsText(f,"UTF-8");
+  }
+}
+
+// update the dropzone visual & call the main parser
+function fileChanged(f) {
+  var dropZone = document.getElementById('filedropzone');
+  gCurrentFile = f;
+  if(gCurrentFile) {
+    var txt;
+    if(gMemFsTotal>1) {
+       txt = "Current file: "+gCurrentFile.name+" (+ "+(gMemFsTotal-1)+" more files)";
+    } else {
+       txt = "Current file: "+gCurrentFile.name;
+    }
+    document.getElementById("currentfile").innerHTML = txt;
+    document.getElementById("filedropzone_filled").style.display = "block";
+    document.getElementById("filedropzone_empty").style.display = "none";
+  } else {
+    document.getElementById("filedropzone_filled").style.display = "none";
+    document.getElementById("filedropzone_empty").style.display = "block";
+  }
+  parseFile(f,false,false);
+}
+
+// check if there were changes: (re-)load all files and check if content was changed
+function superviseAllFiles(p) {
+   console.log("superviseAllFiles()");
+   
+   gMemFsCount = gMemFsTotal = 0;
+   gMemFsChanged = 0;
+   
+   if(p&&p.forceReload) 
+      gMemFsChanged++;
+   
+   if(!gRootFs||gRootFs.length==0||me=='web-offline') {              // walkFileTree won't work with file:// (regardless of chrome|firefox)
+     for(var i=0; i<gCurrentFiles.length; i++) {
+        console.log("[offline] checking "+gCurrentFiles[i].name);
+        gMemFsTotal++;
+        readFileAsync(gCurrentFiles[i]);
+      }
+   } else {
+      for(var i=0; i<gRootFs.length; i++) {
+         walkFileTree(gRootFs[i]);
+      }
+   }
+}
+
+var previousScript = null;
+
+// parse the file (and convert) to a renderable source (jscad)
+function parseFile(f, debugging, onlyifchanged) {
+  if(arguments.length==2) {
+    debugging = arguments[1];
+    onlyifchanged = arguments[2];
+    f = gCurrentFile;
+  }
+  //gCurrentFile = f;
+  var source = f.source;
+  var editorSource = source;
+  if(source == "") {
+    if(document.location.toString().match(/^file\:\//i)) {
+      throw new Error("Could not read file. You are using a local copy of OpenJSCAD.org; if you are using Chrome, you need to launch it with the following command line option:\n\n--allow-file-access-from-files\n\notherwise the browser will not have access to uploaded files due to security restrictions.");
+    } else {
+      throw new Error("Could not read file.");
+    }            
+  } else {         
+    if(gProcessor && ((!onlyifchanged) || (previousScript !== source))) {
+      var fn = gCurrentFile.name;
+      fn = fn.replace(/^.*\/([^\/]*)$/,"$1");     // remove path, leave filename itself
+      gProcessor.setDebugging(debugging); 
+      gEditor.getSession().setMode("ace/mode/javascript");
+      var asyncComputation = false;
+      
+      if(gCurrentFile.lang=='jscad'||gCurrentFile.lang=='js') {
+         ; // default
+      } else if(gCurrentFile.lang=='scad') {
+         editorSource = source;
+         if(!editorSource.match(/^\/\/!OpenSCAD/i)) {
+            editorSource = "//!OpenSCAD\n"+editorSource;
+         }
+         source = openscadOpenJscadParser.parse(editorSource);
+         if(0) {
+            source = "// OpenJSCAD.org: scad importer (openscad-openjscad-translator) '"+fn+"'\n\n"+source;
+         }
+         editor.getSession().setMode("ace/mode/scad");  
+         
+      } else if(gCurrentFile.lang.match(/(stl|obj|amf|gcode)/i)) {
+         status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
+         if(!fn.match(/amf/i)) {     // -- if you debug the STL parsing, change it to 'if(0&&...' so echo() works, otherwise in workers
+                                     //    echo() is not working.., and parseAMF requires jquery, which seem not working in workers
+            var blobURL = new Blob([document.querySelector('#conversionWorker').textContent]);
+            // -- the messy part coming here:
+            var worker = new Worker(window.webkitURL!==undefined?window.webkitURL.createObjectURL(blobURL):window.URL.createObjectURL(blobURL));
+            worker.onmessage = function(e) {
+               var data = e.data;
+               if(data&&data.source&&data.source.length) {              // end of async conversion
+                  putSourceInEditor(data.source,data.filename);
+                  gMemFs[data.filename].source = data.source;
+                  gProcessor.setJsCad(data.source,data.filename);
+               } else {
+                  // worker responds gibberish
+               }
+            };
+            var u = document.location.href;
+            u = u.replace(/#.*$/,'');
+            u = u.replace(/\?.*$/,'');
+            worker.postMessage({me: me, version: version, url: u, source: source, filename: fn });
+            asyncComputation = true;
+         } else {
+            fn.match(/\.(stl|obj|amf|gcode)$/i);
+            var type = RegExp.$1;
+            if(type=='obj') {
+               editorSource = source = parseOBJ(source,fn);   
+            } else if(type=='amf') {
+               editorSource = source = parseAMF(source,fn);   
+            } else if(type=='gcode') {
+               editorSource = source = parseGCode(source,fn);   
+            } else {
+               editorSource = source = parseSTL(source,fn);   
+            }
+         }
+      } else {
+         throw new Error("Please drop a file with .jscad, .scad or .stl extension");
+      }
+      if(!asyncComputation) {                   // end of synchronous conversion
+         putSourceInEditor(editorSource,fn);
+         gMemFs[fn].source = source;
+         gProcessor.setJsCad(source,fn);
+      }
+    }
+  }
+}

--- a/js/ui-drag-drop.js
+++ b/js/ui-drag-drop.js
@@ -1,6 +1,6 @@
 // -----------------------------------------------------------------------------------------------------------
 // Drag'n'Drop Functionality
-// from old OpenJsCad processfile.html by Joost Nieuwenhuijse, 
+// from old OpenJsCad processfile.html by Joost Nieuwenhuijse,
 //     with changes by Rene K. Mueller
 // History:
 // 2013/04/02: massively upgraded to support multiple-files (chrome & firefox) and entire directory drag'n'drop (chrome only)
@@ -34,24 +34,22 @@ function setupDragDrop() {
     evt.dataTransfer.dropEffect = 'copy';
   }, false);
   dropZone.addEventListener('drop', handleFileSelect, false);
-}
+};
 
 function reloadAllFiles() {
   superviseAllFiles({forceReload:true});
-}
+};
 
 function toggleAutoReload() {
-   if (document.getElementById("autoreload").checked) {
-      autoReloadTimer = setInterval(function(){
-        superviseAllFiles();
-    }, 1000);
-   } else {
-      if (autoReloadTimer !== null) {
-         clearInterval(autoReloadTimer);
-         autoReloadTimer = null;
-      }
-   }
-}
+  if (document.getElementById("autoreload").checked) {
+    autoReloadTimer = setInterval(function(){superviseAllFiles();}, 1000);
+  } else {
+    if (autoReloadTimer !== null) {
+      clearInterval(autoReloadTimer);
+      autoReloadTimer = null;
+    }
+  }
+};
 
 // --- Private Variables
 var autoReloadTimer = null;
@@ -86,63 +84,63 @@ function handleFileSelect(evt) {
        gRootFs.push(items[i].webkitGetAsEntry());
     }
   }
+// FIXME determine existance of functionality via other methods
   if(browser=='firefox' || me=='web-offline') {     // -- fallback, walkFileTree won't work with file://
-     if(evt.dataTransfer.files.length>0) {
-       gCurrentFiles = [];                              // -- be aware: gCurrentFiles = evt.dataTransfer.files won't work, as rewriting file will mess up the array
-       for(var i=0; i<evt.dataTransfer.files.length; i++) {
-         gCurrentFiles.push(evt.dataTransfer.files[i]);  // -- need to transfer the single elements
-       }
-       loadLocalFiles();
-     } else {
-       throw new Error("Please drop a single jscad, scad, stl file, or multiple jscad files");
-     }
+    if(evt.dataTransfer.files.length>0) {
+      gCurrentFiles = [];                              // -- be aware: gCurrentFiles = evt.dataTransfer.files won't work, as rewriting file will mess up the array
+      for(var i=0; i<evt.dataTransfer.files.length; i++) {
+        gCurrentFiles.push(evt.dataTransfer.files[i]);  // -- need to transfer the single elements
+      }
+      loadLocalFiles();
+    } else {
+      throw new Error("Please drop a single jscad, scad, stl file, or multiple jscad files");
+    }
   }
-}
+};
 
 // this is the core of the drag'n'drop:
 //    1) walk the tree
 //    2) read the files (readFileAsync)
 //    3) re-render if there was a change (via readFileAsync)
 function walkFileTree(item,path) {
-   path = path||"";
-   //console.log("item=",item);
-   if(item.isFile) {
-      item.file(function(file) {                // this is also asynchronous ... (making everything complicate)
-         if(file.name.match(/\.(jscad|js|scad|obj|stl|amf|gcode)$/)) {   // FIXME now all files OpenJSCAD can handle
-            console.log("walkFileTree File: "+path+item.name);
-            gMemFsTotal++;
-            gCurrentFiles.push(file);
-            readFileAsync(file);
-         }
-      });
-
-   } else if(item.isDirectory) {
-      var dirReader = item.createReader();
-      console.log("walkFileTree Folder: "+item.name);
-      dirReader.readEntries(function(entries) {
-        // console.log("===",entries,entries.length);
-         for(var i=0; i<entries.length; i++) {
-            //console.log(i,entries[i]);
-            walkFileTree(entries[i],path+item.name+"/");
-         }
-      });
-   }
-}
+ path = path||"";
+ //console.log("item=",item);
+ if(item.isFile) {
+   item.file(function(file) {                // this is also asynchronous ... (making everything complicate)
+     if(file.name.match(/\.(jscad|js|scad|obj|stl|amf|gcode)$/)) {   // FIXME now all files OpenJSCAD can handle
+       console.log("walkFileTree File: "+path+item.name);
+       gMemFsTotal++;
+       gCurrentFiles.push(file);
+       readFileAsync(file);
+     }
+   });
+  } else if(item.isDirectory) {
+    var dirReader = item.createReader();
+    console.log("walkFileTree Folder: "+item.name);
+    dirReader.readEntries(function(entries) {
+      // console.log("===",entries,entries.length);
+      for(var i=0; i<entries.length; i++) {
+        //console.log(i,entries[i]);
+        walkFileTree(entries[i],path+item.name+"/");
+      }
+    });
+  }
+};
 
 // this is the linear drag'n'drop, a list of files to read (when folders aren't supported)
 function loadLocalFiles() {
   var items = gCurrentFiles;
   console.log("loadLocalFiles",items);
   gMemFsCount = 0;
-  gMemFsTotal = items.length;      
+  gMemFsTotal = items.length;
   gMemFsChanged = 0;
-  
+
   for(var i=0; i<items.length; i++) {
-     var f = items[i];
-     console.log(f);
-     readFileAsync(f);
+    var f = items[i];
+    console.log(f);
+    readFileAsync(f);
   }
-}
+};
 
 // set one file (the one dragged) or main.jscad
 function setCurrentFile(file) {
@@ -156,73 +154,74 @@ function setCurrentFile(file) {
   }
   if(file.size == 0) {
     throw new Error("You have dropped an empty file");
-  }              
+  }
   fileChanged(file);
-}     
+};
 
-// RANT: JavaScript at its finest: 50 lines code to read a SINGLE file 
+// RANT: JavaScript at its finest: 50 lines code to read a SINGLE file
 //       this code looks complicate and it is complicate.
 function readFileAsync(f) {
-  var reader = new FileReader();
-
   console.log("request: "+f.name+" ("+f.fullPath+")");
+
+  var reader = new FileReader();
   reader.onloadend = function(evt) {
-     if(evt.target.readyState == FileReader.DONE) {
-        var source = evt.target.result;
+    if(evt.target.readyState == FileReader.DONE) {
+      var source = evt.target.result;
 
-        console.log("done reading: "+f.name,source?source.length:0);   // it could have been vanished while fetching (race condition)
-        gMemFsCount++;
-        
-        if(!gMemFs[f.name]||gMemFs[f.name].source!=source)     // note: assigning f.source = source too make gMemFs[].source the same, therefore as next
-          gMemFsChanged++;
+      console.log("done reading: "+f.name,source?source.length:0);   // it could have been vanished while fetching (race condition)
+      gMemFsCount++;
 
-        f.source = source;                 // -- do it after comparing
-         
-        gMemFs[f.name] = f;                // -- we cache the file (and its actual content)
+     // note: assigning f.source = source too make gMemFs[].source the same, therefore as next
+      if(!gMemFs[f.name]||gMemFs[f.name].source!=source)
+        gMemFsChanged++;
 
-        if(gMemFsCount==gMemFsTotal) {                // -- are we done reading all?
-           console.log("all "+gMemFsTotal+" files read.");
-           if(gMemFsTotal>1||gMemFsCount>1) {         // we deal with multiple files, so we hide the editor to avoid confusion
-             $('#editor').hide();
-           } else {
-             $('#editor').show();
-           }
-           
-           if(gMemFsTotal>1) {
-              if(gMemFs['main.jscad']) {
-                 gMainFile = gMemFs['main.jscad'];
-              } else if(gMemFs['main.js']) {
-                 gMainFile = gMemFs['main.js'];
-              } else {
-                 for(var fn in gMemFs) {
-                   if(gMemFs[fn].name.match(/\/main.jscad$/)||gMemFs[fn].name.match(/\/main.js$/)) {
-                      gMainFile = gMemFs[fn];
-                   }
-                 }
-              }
-           } else {
-             gMainFile = f;  
-           }
-           if(gMemFsChanged>0) {
-              if(!gMainFile)
-                throw("No main.jscad found");
-              console.log("update & redraw "+gMainFile.name);
-              setCurrentFile(gMainFile);
-           }
+      f.source = source;                 // -- do it after comparing
+
+      gMemFs[f.name] = f;                // -- we cache the file (and its actual content)
+
+      if(gMemFsCount==gMemFsTotal) {                // -- are we done reading all?
+        console.log("all "+gMemFsTotal+" files read.");
+        if(gMemFsTotal>1||gMemFsCount>1) {         // we deal with multiple files, so we hide the editor to avoid confusion
+          $('#editor').hide();
+        } else {
+          $('#editor').show();
         }
-     
-     } else {
-        throw new Error("Failed to read file");
-        if(gProcessor) gProcessor.clearViewer();
+
+        if(gMemFsTotal>1) {
+          if(gMemFs['main.jscad']) {
+            gMainFile = gMemFs['main.jscad'];
+          } else if(gMemFs['main.js']) {
+            gMainFile = gMemFs['main.js'];
+          } else {
+            for(var fn in gMemFs) {
+              if(gMemFs[fn].name.match(/\/main.jscad$/)||gMemFs[fn].name.match(/\/main.js$/)) {
+                gMainFile = gMemFs[fn];
+              }
+            }
+          }
+        } else {
+          gMainFile = f;
+        }
+        if(gMemFsChanged>0) {
+          if(!gMainFile)
+            throw("No main.jscad found");
+            console.log("update & redraw "+gMainFile.name);
+            setCurrentFile(gMainFile);
+         }
+      }
+    } else {
+      throw new Error("Failed to read file");
+      if(gProcessor) gProcessor.clearViewer();
         previousScript = null;
-     }
+    }
   };
+
   if(f.name.match(/\.(stl|gcode)$/)) { // FIXME how to determine?
-     reader.readAsBinaryString(f,"UTF-8");
+    reader.readAsBinaryString(f,"UTF-8");
   } else {
-     reader.readAsText(f,"UTF-8");
+    reader.readAsText(f,"UTF-8");
   }
-}
+};
 
 // update the dropzone visual & call the main parser
 function fileChanged(f) {
@@ -231,9 +230,9 @@ function fileChanged(f) {
   if(gCurrentFile) {
     var txt;
     if(gMemFsTotal>1) {
-       txt = "Current file: "+gCurrentFile.name+" (+ "+(gMemFsTotal-1)+" more files)";
+      txt = "Current file: "+gCurrentFile.name+" (+ "+(gMemFsTotal-1)+" more files)";
     } else {
-       txt = "Current file: "+gCurrentFile.name;
+      txt = "Current file: "+gCurrentFile.name;
     }
     document.getElementById("currentfile").innerHTML = txt;
     document.getElementById("filedropzone_filled").style.display = "block";
@@ -243,30 +242,30 @@ function fileChanged(f) {
     document.getElementById("filedropzone_empty").style.display = "block";
   }
   parseFile(f,false,false);
-}
+};
 
 // check if there were changes: (re-)load all files and check if content was changed
 function superviseAllFiles(p) {
-   console.log("superviseAllFiles()");
-   
-   gMemFsCount = gMemFsTotal = 0;
-   gMemFsChanged = 0;
-   
-   if(p&&p.forceReload) 
-      gMemFsChanged++;
-   
-   if(!gRootFs||gRootFs.length==0||me=='web-offline') {              // walkFileTree won't work with file:// (regardless of chrome|firefox)
-     for(var i=0; i<gCurrentFiles.length; i++) {
-        console.log("[offline] checking "+gCurrentFiles[i].name);
-        gMemFsTotal++;
-        readFileAsync(gCurrentFiles[i]);
-      }
-   } else {
-      for(var i=0; i<gRootFs.length; i++) {
-         walkFileTree(gRootFs[i]);
-      }
-   }
-}
+  console.log("superviseAllFiles()");
+
+  gMemFsCount = gMemFsTotal = 0;
+  gMemFsChanged = 0;
+
+  if(p&&p.forceReload)
+    gMemFsChanged++;
+
+  if(!gRootFs||gRootFs.length==0||me=='web-offline') {              // walkFileTree won't work with file:// (regardless of chrome|firefox)
+    for(var i=0; i<gCurrentFiles.length; i++) {
+      console.log("[offline] checking "+gCurrentFiles[i].name);
+      gMemFsTotal++;
+      readFileAsync(gCurrentFiles[i]);
+    }
+  } else {
+    for(var i=0; i<gRootFs.length; i++) {
+      walkFileTree(gRootFs[i]);
+    }
+  }
+};
 
 var previousScript = null;
 
@@ -280,76 +279,72 @@ function parseFile(f, debugging, onlyifchanged) {
   //gCurrentFile = f;
   var source = f.source;
   var editorSource = source;
+
   if(source == "") {
     if(document.location.toString().match(/^file\:\//i)) {
       throw new Error("Could not read file. You are using a local copy of OpenJSCAD.org; if you are using Chrome, you need to launch it with the following command line option:\n\n--allow-file-access-from-files\n\notherwise the browser will not have access to uploaded files due to security restrictions.");
-    } else {
-      throw new Error("Could not read file.");
-    }            
-  } else {         
-    if(gProcessor && ((!onlyifchanged) || (previousScript !== source))) {
-      var fn = gCurrentFile.name;
-      fn = fn.replace(/^.*\/([^\/]*)$/,"$1");     // remove path, leave filename itself
-      gProcessor.setDebugging(debugging); 
-      gEditor.getSession().setMode("ace/mode/javascript");
-      var asyncComputation = false;
-      
-      if(gCurrentFile.lang=='jscad'||gCurrentFile.lang=='js') {
-         ; // default
-      } else if(gCurrentFile.lang=='scad') {
-         editorSource = source;
-         if(!editorSource.match(/^\/\/!OpenSCAD/i)) {
-            editorSource = "//!OpenSCAD\n"+editorSource;
-         }
-         source = openscadOpenJscadParser.parse(editorSource);
-         if(0) {
-            source = "// OpenJSCAD.org: scad importer (openscad-openjscad-translator) '"+fn+"'\n\n"+source;
-         }
-         editor.getSession().setMode("ace/mode/scad");  
-         
-      } else if(gCurrentFile.lang.match(/(stl|obj|amf|gcode)/i)) {
-         status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
-         if(!fn.match(/amf/i)) {     // -- if you debug the STL parsing, change it to 'if(0&&...' so echo() works, otherwise in workers
-                                     //    echo() is not working.., and parseAMF requires jquery, which seem not working in workers
-            var blobURL = new Blob([document.querySelector('#conversionWorker').textContent]);
-            // -- the messy part coming here:
-            var worker = new Worker(window.webkitURL!==undefined?window.webkitURL.createObjectURL(blobURL):window.URL.createObjectURL(blobURL));
-            worker.onmessage = function(e) {
-               var data = e.data;
-               if(data&&data.source&&data.source.length) {              // end of async conversion
-                  putSourceInEditor(data.source,data.filename);
-                  gMemFs[data.filename].source = data.source;
-                  gProcessor.setJsCad(data.source,data.filename);
-               } else {
-                  // worker responds gibberish
-               }
-            };
-            var u = document.location.href;
-            u = u.replace(/#.*$/,'');
-            u = u.replace(/\?.*$/,'');
-            worker.postMessage({me: me, version: version, url: u, source: source, filename: fn });
-            asyncComputation = true;
-         } else {
-            fn.match(/\.(stl|obj|amf|gcode)$/i);
-            var type = RegExp.$1;
-            if(type=='obj') {
-               editorSource = source = parseOBJ(source,fn);   
-            } else if(type=='amf') {
-               editorSource = source = parseAMF(source,fn);   
-            } else if(type=='gcode') {
-               editorSource = source = parseGCode(source,fn);   
-            } else {
-               editorSource = source = parseSTL(source,fn);   
-            }
-         }
+    }
+    throw new Error("Could not read file.");
+  }
+
+  if(gProcessor && ((!onlyifchanged) || (previousScript !== source))) {
+    var fn = gCurrentFile.name;
+    fn = fn.replace(/^.*\/([^\/]*)$/,"$1");     // remove path, leave filename itself
+    gProcessor.setDebugging(debugging);
+    var asyncComputation = false;
+
+    if(gCurrentFile.lang=='jscad'||gCurrentFile.lang=='js') {
+      ; // default
+    } else if(gCurrentFile.lang=='scad') {
+      if(!editorSource.match(/^\/\/!OpenSCAD/i)) {
+        editorSource = "//!OpenSCAD\n"+editorSource;
+      }
+      source = openscadOpenJscadParser.parse(editorSource);
+      editor.getSession().setMode("ace/mode/scad");
+
+    } else if(gCurrentFile.lang.match(/(stl|obj|amf|gcode)/i)) {
+      status("Converting "+fn+" <img id=busy src='imgs/busy.gif'>");
+      if(!fn.match(/amf/i)) {     // -- if you debug the STL parsing, change it to 'if(0&&...' so echo() works, otherwise in workers
+                                  //    echo() is not working.., and parseAMF requires jquery, which seem not working in workers
+        var blobURL = new Blob([document.querySelector('#conversionWorker').textContent]);
+        // -- the messy part coming here:
+        var worker = new Worker(window.webkitURL!==undefined?window.webkitURL.createObjectURL(blobURL):window.URL.createObjectURL(blobURL));
+        worker.onmessage = function(e) {
+          var data = e.data;
+          if(data&&data.source&&data.source.length) {              // end of async conversion
+            putSourceInEditor(data.source,data.filename);
+            gMemFs[data.filename].source = data.source;
+            gProcessor.setJsCad(data.source,data.filename);
+          } else {
+            // worker responds gibberish
+          }
+        };
+        var u = document.location.href;
+        u = u.replace(/#.*$/,'');
+        u = u.replace(/\?.*$/,'');
+        worker.postMessage({me: me, version: version, url: u, source: source, filename: fn });
+        asyncComputation = true;
       } else {
-         throw new Error("Please drop a file with .jscad, .scad or .stl extension");
+        fn.match(/\.(stl|obj|amf|gcode)$/i);
+        var type = RegExp.$1;
+        if(type=='obj') {
+          editorSource = source = parseOBJ(source,fn);
+        } else if(type=='amf') {
+          editorSource = source = parseAMF(source,fn);
+        } else if(type=='gcode') {
+          editorSource = source = parseGCode(source,fn);
+        } else {
+          editorSource = source = parseSTL(source,fn);
+        }
       }
-      if(!asyncComputation) {                   // end of synchronous conversion
-         putSourceInEditor(editorSource,fn);
-         gMemFs[fn].source = source;
-         gProcessor.setJsCad(source,fn);
-      }
+    } else {
+      throw new Error("Please drop a file with .jscad, .scad or .stl extension");
+    }
+    if(!asyncComputation) {                   // end of synchronous conversion
+      putSourceInEditor(editorSource,fn);
+      gMemFs[fn].source = source;
+      gProcessor.setJsCad(source,fn);
     }
   }
-}
+};
+

--- a/js/ui-editor.js
+++ b/js/ui-editor.js
@@ -77,7 +77,7 @@ function putSourceInEditor(src,fn) {
     if(!src.match(/^\/\/!OpenSCAD/i)) {
       gEditor.getSession().setMode("ace/mode/scad");
     } else {
-      gEditor.getSession().setMode("ace/mode/js");
+      gEditor.getSession().setMode("ace/mode/javascript");
     }
   }
 }

--- a/js/ui-editor.js
+++ b/js/ui-editor.js
@@ -1,0 +1,91 @@
+// -----------------------------------------------------------------------------------------------------------
+// Editor Functionality
+
+// --- Dependencies
+// gProcessor var
+// #editor element
+
+// --- Global Variables
+var gEditor = null;
+
+// See http://ace.ajax.org/#nav=howto
+function setUpEditor(divname) {
+  if (divname === undefined) { divname = 'editor'; }
+  if (document.getElementById(divname) === null) return;
+
+  gEditor = ace.edit(divname);
+  gEditor.$blockScrolling = Infinity;
+  gEditor.getSession().setMode("ace/mode/javascript");
+  gEditor.getSession().on('change', function(e) { ; });
+  //gEditor.setTheme("ace/theme/ambiance");
+  //gEditor.setTheme("ace/theme/chaos");
+  gEditor.setTheme("ace/theme/chrome");
+  //gEditor.setTheme("ace/theme/clouds");
+  //gEditor.setTheme("ace/theme/cobalt");
+  //gEditor.setTheme("ace/theme/dawn"); // nice
+  //gEditor.setTheme("ace/theme/dreamweaver");
+  //gEditor.setTheme("ace/theme/eclipse");
+  //gEditor.setTheme("ace/theme/github");
+  //gEditor.setTheme("ace/theme/idle_fingers");
+  //gEditor.setTheme("ace/theme/katzenmilch");
+  //gEditor.setTheme("ace/theme/kr_theme");
+  //gEditor.setTheme("ace/theme/kuroir");
+  //gEditor.setTheme("ace/theme/merbivore");
+  //gEditor.setTheme("ace/theme/mono_industrial");
+  //gEditor.setTheme("ace/theme/monokai");
+  //gEditor.setTheme("ace/theme/pastel_on_dark");
+  //gEditor.setTheme("ace/theme/solarized_dark");
+  //gEditor.setTheme("ace/theme/solarized_light");
+  //gEditor.setTheme("ace/theme/terminal");
+  //gEditor.setTheme("ace/theme/textmate");
+  //gEditor.setTheme("ace/theme/tomorrow");
+  //gEditor.setTheme("ace/theme/tomorrow_night");
+  //gEditor.setTheme("ace/theme/tomorrow_night_blue");
+  //gEditor.setTheme("ace/theme/tomorrow_night_bright");
+  //gEditor.setTheme("ace/theme/tomorrow_night_eighties");
+  //gEditor.setTheme("ace/theme/twilight");
+  //gEditor.setTheme("ace/theme/vibrant_ink");
+  //gEditor.setTheme("ace/theme/xcode");
+
+// enable special keystrokes
+  ['Shift-Return'].forEach(function(key) {
+    gEditor.commands.addCommand({
+         name: 'myCommand',
+         bindKey: { win: key, mac: key },
+         exec: function(editor) {
+            var src = editor.getValue();
+            if(src.match(/^\/\/\!OpenSCAD/i)) {
+               editor.getSession().setMode("ace/mode/scad");
+            // FIXME test for the global function first
+               src = openscadOpenJscadParser.parse(src);
+            } else {
+               editor.getSession().setMode("ace/mode/javascript");
+            }
+            if (gProcessor !== null) {
+              gProcessor.setJsCad(src);
+            }
+         },
+      });
+  });
+}
+
+function putSourceInEditor(src,fn) {
+  if (gEditor !== null) {
+    gEditor.setValue(src);
+    gEditor.clearSelection();
+    gEditor.navigateFileStart();
+    if(!src.match(/^\/\/!OpenSCAD/i)) {
+      gEditor.getSession().setMode("ace/mode/scad");
+    } else {
+      gEditor.getSession().setMode("ace/mode/js");
+    }
+  }
+}
+
+function getSourceFromEditor() {
+  if (gEditor !== null) {
+    return gEditor.getValue();
+  }
+  return '';
+}
+

--- a/js/ui-worker.js
+++ b/js/ui-worker.js
@@ -1,0 +1,29 @@
+// Create an worker (thread) for converting various formats to JSCAD
+//
+// See worker-conversion.js for the conversion process
+//
+function createConversionWorker() {
+  var w = new Worker('js/worker-conversion.js');
+// when the worker finishes
+// - put the converted source into the editor
+// - save the converted source into the cache (gMemFs)
+// - set the converted source into the processor (viewer)
+  w.onmessage = function(e) {
+      if (e.data instanceof Object) {
+        var data = e.data;
+        if ('filename' in data && 'source' in data) {
+          //console.log("editor"+data.source+']');
+          putSourceInEditor(data.source,data.filename);
+        }
+        if ('filename' in data && 'converted' in data) {
+          //console.log("processor: "+data.filename+" ["+data.converted+']');
+          if ('cache' in data && data.cache == true) {
+            saveScript(data.filename,data.converted);
+          }
+          gProcessor.setJsCad(data.converted,data.filename);
+        }
+      }
+    };
+  return w;
+};
+

--- a/js/worker-conversion.js
+++ b/js/worker-conversion.js
@@ -1,0 +1,84 @@
+// -----------------------------------------------------------------------------------------------------------
+// Implementation of Conversion Worker Thread
+//
+// See ui-workers.js for helper functions
+// See index.js for how to create and start this thread
+
+// Handle the onmessage event which starts the thread
+// The "event" (message) is expected to have:
+//   data - an anonymous object for passing data
+//   data.url      - url of the page
+//   data.filename - name of the source file
+//   data.source   - contents of the source file
+//
+// A message is posted back to the main thread with:
+//   source    - source code for the editor (See logic below)
+//   converted - converted code for the processor (See logic below)
+// Depending on what's being converted, the two are different or the same.
+//
+// NOTE: Additional scripts (libraries) are imported only if necessary
+onmessage = function (e) {
+  var r = { source: "", converted: "", filename: "", url: "", cache: false };
+  if (e.data instanceof Object) {
+    var data = e.data;
+    var baseurl = '';
+    if ('cache' in data) {
+      r.cache = data.cache; // forward cache (gMemFS) controls
+    }
+    if ('url' in data) {
+      r.url = data.url;
+      baseurl = data.url;
+      baseurl = baseurl.replace(/#.*$/,'');    // -- just to be sure ...
+      baseurl = baseurl.replace(/\?.*$/,'');
+      var index = baseurl.indexOf('index.html');
+      if(index >= 0) {
+         baseurl = baseurl.substring(0,index);
+      }
+    }
+    if ('filename' in data) {
+      r.filename = data.filename;
+      if ('source' in data) {
+        r.source = data.source;
+      // FIXME this list should come from a global list
+        var e = data.filename.toLowerCase().match(/\.(jscad|js|scad|stl|obj|amf|gcode)$/i);
+        e = RegExp.$1;
+        switch (e) {
+          case 'amf':
+          // FIXME correct the importScripts once JQUERY is not required
+            importScripts(baseurl+'csg.js',baseurl+'openjscad.js',baseurl+'openscad.js');
+            r.source = r.converted = parseAMF(data.source,data.filename);
+            break;
+          case 'gcode':
+            importScripts(baseurl+'csg.js',baseurl+'openjscad.js',baseurl+'openscad.js');
+            r.source = r.converted = parseGCode(data.source,data.filename);
+            break;
+          case 'obj':
+            importScripts(baseurl+'csg.js',baseurl+'openjscad.js',baseurl+'openscad.js');
+            r.source = r.converted = parseOBJ(data.source,data.filename);
+            break;
+          case 'scad':
+            importScripts(baseurl+'csg.js',baseurl+'openjscad.js',baseurl+'openscad.js',baseurl+'underscore.js',baseurl+'openscad-openjscad-translator.js');
+            r.source = data.source;
+            if(!r.source.match(/^\/\/!OpenSCAD/i)) {
+               r.source = "//!OpenSCAD\n"+data.source;
+            }
+            r.converted = openscadOpenJscadParser.parse(r.source);
+            break;
+          case 'stl':
+            importScripts(baseurl+'csg.js',baseurl+'openjscad.js',baseurl+'openscad.js');
+            r.source = r.converted = parseSTL(data.source,data.filename);
+            break;
+          case 'js':
+            r.source = r.converted = data.source;
+            break;
+          case 'jscad':
+            r.source = r.converted = data.source;
+            break;
+          default:
+            break;
+        }
+      }
+    }
+  }
+  postMessage(r);
+};

--- a/min.css
+++ b/min.css
@@ -1,0 +1,107 @@
+/*
+ * min.css for OpenJSCAD.org viewer
+ */
+
+.jscad-container {
+  margin: 5px 15px 5px 5px; /* not inherited */
+  padding: 20px; /* not inherited */
+  color: Black;
+  font-weight: bold;
+  font-family: Helvetica, Arial, Sans;
+  border: thin solid black;
+  min-width: 410px;
+}
+
+#header {
+  margin: 5px; /* not inherited */
+}
+
+#viewerContext {
+  margin: 5px; /* not inherited */
+  border: thin solid gray; /* not inherited */
+  padding: 0px; /* not inherited */
+
+  background: white;
+  width: 400px;
+  height: 300px;
+
+  top: 0px;
+  bottom: 0px;
+}
+
+canvas { 
+  margin: 0px; /* not inherited */
+  border: 0px none gray; /* not inherited */
+  padding: 0px; /* not inherited */
+
+  width: 100%;
+  height: 100%;
+
+  cursor: move; 
+}
+
+#parametersdiv {
+  margin: 5px; /* not inherited */
+  border: thin solid rgb(200,200,200);
+  border-radius: 1em;     
+  padding: 10px;
+
+  background: white;
+  opacity: 0.8;
+}
+
+#parametersdiv table {
+  margin-bottom: 5px;
+
+  text-align: left;
+  font-size: 0.8em;
+  font-weight: normal;
+}
+
+#parametersdiv th {
+  margin:  0px; /* not inherited */
+  border:  0px none gray; /* not inherited */
+  padding: 5px; /* not inherited */
+
+  font-weight: bold;
+}
+
+#parametersdiv th.caption {
+  text-decoration: underline;
+}
+
+#parametersdiv td.caption {
+  text-align: right;
+  font-weight: bold;
+}
+
+#parametersdiv td {
+  margin:  0px; /* not inherited */
+  border:  0px none gray; /* not inherited */
+  padding: 0px; /* not inherited */
+}
+
+#parametersdiv input, #parametersdiv textarea, #parametersdiv select {
+  font-size: 0.9em;
+  background: #fea;
+  border: none;
+}
+
+#updateButton {
+  margin:  5px; /* not inherited */
+  border:  thin solid Black; /* not inherited */
+  padding: 2px; /* not inherited */
+  border-radius: 4px;
+  background: white;
+
+  margin-left: 1em;
+}
+
+#tail { 
+  margin: 5px; /* not inherited */
+}
+
+#busy {
+  vertical-align: middle;
+}
+

--- a/min.html
+++ b/min.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+  <title>OpenJSCAD.org Logo</title>
+  <script src="jquery/jquery-1.9.1.js"></script>
+  <script src="jquery/jquery.hammer.js"></script>
+  <script src="lightgl.js"></script>
+  <script src="csg.js"></script>
+  <script src="formats.js"></script>
+  <script src="openjscad.js"></script>
+  <script src="openscad.js"></script>
+  <link rel="stylesheet" href="min.css" type="text/css">
+</head>
+
+<body onload="loadProcessor()">
+<!-- setup display of the errors as required by OpenJSCAD.js -->
+  <div class="jscad-container">
+    <div id="header">
+      <div id="errordiv">hello</div>
+    </div>
+
+<!-- setup display of the viewer, i.e. canvas -->
+    <div oncontextmenu="return false;" id="viewerContext"></div>
+
+<!-- setup display of the design parameters, as required by OpenJSCAD.js -->
+<!-- set display: block to display this -->
+    <div id="parametersdiv" style="display: none;"></div>
+
+<!-- setup display of the status, as required by OpenJSCAD.js -->
+<!-- set display: block to display this -->
+    <div id="tail" style="display: none;">
+      <div id="statusdiv"></div>
+    </div>
+  </div>
+
+<!-- define the design and the parameters -->
+  <script type="text/javascript">
+    var gProcessor = null;        // required by OpenJScad.org
+    var gMemFs = [];              // required by OpenJScad.org
+    var _includePath = './';      // required by OpenJScad.org
+
+    var gComponents = [ { file: 'examples/logo.jscad' } ];
+
+    function loadProcessor() {
+      gProcessor = new OpenJsCad.Processor(document.getElementById("viewerContext"));
+
+      loadJSCAD(0);
+    }
+
+    function loadJSCAD(choice) {
+      var filepath = gComponents[choice].file;
+      var xhr = new XMLHttpRequest();
+      xhr.open("GET", filepath, true);
+      OpenJsCad.status("Loading "+filepath+" <img id=busy src='imgs/busy.gif'>");
+
+      xhr.onload = function() {
+        var source = this.responseText;
+        console.log(source);
+
+        if(filepath.match(/\.jscad$/i)||filepath.match(/\.js$/i)) {
+          OpenJsCad.status("Processing "+filepath+" <img id=busy src='imgs/busy.gif'>");
+          gProcessor.setJsCad(source,filepath);
+        }
+      }
+      xhr.send();
+    }
+  </script>
+
+</body>
+
+</html> 

--- a/openjscad.css
+++ b/openjscad.css
@@ -90,11 +90,6 @@ canvas {
   border: none;
 }
 
-#parametersdiv .parameterheader {
-   font-weight: bold;
-   font-size: 0.9em;
-}
-
 #parametersdiv .caption {
    text-align: right;
 }

--- a/openjscad.js
+++ b/openjscad.js
@@ -654,7 +654,6 @@ OpenJsCad.parseJsCadScriptSync = function(script, mainParameters, debugging) {
     workerscript += "\n\n// Now press F11 twice to enter your main() function:\n\n";
     workerscript += "debugger;\n";
   }
-  workerscript += "var me = " + JSON.stringify(me) + ";\n";
   workerscript += "return main("+JSON.stringify(mainParameters)+");";  
 // trying to get include() somewhere:
 // 1) XHR works for SYNC <---
@@ -732,7 +731,6 @@ OpenJsCad.parseJsCadScriptASync = function(script, mainParameters, options, call
     }
   }
   var workerscript = "//ASYNC\n";
-  workerscript += "var me = " + JSON.stringify(me) + ";\n";
   workerscript += "var _csg_baseurl=" + JSON.stringify(baseurl)+";\n";        // -- we need it early for include()
   workerscript += "var _includePath=" + JSON.stringify(_includePath)+";\n";    //        ''            ''
   workerscript += "var gMemFs = [];\n";

--- a/openjscad.js
+++ b/openjscad.js
@@ -60,6 +60,14 @@ OpenJsCad.Viewer = function(containerelement, initialdepth) {
   this.viewpointX = 0;
   this.viewpointY = -5;
   this.viewpointZ = initialdepth;
+  this.onZoomChanged = null;
+  this.plate = true;  // render plate
+
+  // state of view
+  // 0 - initialized, no object
+  // 1 - cleared, no object
+  // 2 - showing, object
+  this.state = 0;
 
   this.touch = {
     lastX: 0,
@@ -264,13 +272,6 @@ OpenJsCad.Viewer.prototype = {
 
   ZOOM_MAX: 1000,
   ZOOM_MIN: 10,
-  onZoomChanged: null,
-  plate: true,                   // render plate
-  // state of view
-  // 0 - initialized, no object
-  // 1 - cleared, no object
-  // 2 - showing, object
-  state: 0,
 
   setZoom: function(coeff) { //0...1
     coeff=Math.max(coeff, 0);
@@ -706,6 +707,7 @@ OpenJsCad.parseJsCadScriptSync = function(script, mainParameters, debugging) {
 OpenJsCad.parseJsCadScriptASync = function(script, mainParameters, options, callback) {
   var baselibraries = [
     "csg.js",
+    "formats.js",
     "openjscad.js",
     "openscad.js"
     //"jquery/jquery-1.9.1.js",
@@ -956,7 +958,7 @@ OpenJsCad.getParamDefinitions = function(script) {
 OpenJsCad.Processor = function(containerdiv, onchange) {
   this.containerdiv = containerdiv;
   this.onchange = onchange;
-  this.viewerdiv = null;
+
   this.viewer = null;
   this.zoomControl = null;
   //this.viewerwidth = 1200;
@@ -1027,13 +1029,12 @@ OpenJsCad.Processor.prototype = {
     viewerdiv.style.width = '100%';
     viewerdiv.style.height = '100%';
     this.containerdiv.appendChild(viewerdiv);
-    this.viewerdiv = viewerdiv;
     try {
-      //this.viewer = new OpenJsCad.Viewer(this.viewerdiv, this.viewerwidth, this.viewerheight, this.initialViewerDistance);
-      //this.viewer = new OpenJsCad.Viewer(this.viewerdiv, viewerdiv.offsetWidth, viewer.offsetHeight, this.initialViewerDistance);
-      this.viewer = new OpenJsCad.Viewer(this.viewerdiv, this.initialViewerDistance);
+      //this.viewer = new OpenJsCad.Viewer(viewerdiv, this.viewerwidth, this.viewerheight, this.initialViewerDistance);
+      //this.viewer = new OpenJsCad.Viewer(viewerdiv, viewerdiv.offsetWidth, viewer.offsetHeight, this.initialViewerDistance);
+      this.viewer = new OpenJsCad.Viewer(viewerdiv, this.initialViewerDistance);
     } catch(e) {
-      this.viewerdiv.innerHTML = "<b><br><br>Error: " + e.toString() + "</b><br><br>OpenJsCad currently requires Google Chrome or Firefox with WebGL enabled";
+      viewerdiv.innerHTML = "<b><br><br>Error: " + e.toString() + "</b><br><br>OpenJsCad currently requires Google Chrome or Firefox with WebGL enabled";
     }
     //Zoom control
     if(0) {

--- a/openjscad.js
+++ b/openjscad.js
@@ -672,14 +672,11 @@ OpenJsCad.parseJsCadScriptSync = function(script, mainParameters, debugging) {
       }\
       importScripts(url+fn);\
     } else {\
-      //console.log('SYNC checking gMemFs for '+fn);\
       if(gMemFs[fn]) {\
-        //console.log('found locally & eval:',gMemFs[fn].name);\
         eval(gMemFs[fn].source); return;\
       }\
       var xhr = new XMLHttpRequest();\
       xhr.open('GET',_includePath+fn,false);\
-      //console.log('include:'+_includePath+fn);\
       xhr.onload = function() {\
         var src = this.responseText;\
         eval(src);\
@@ -731,7 +728,7 @@ OpenJsCad.parseJsCadScriptASync = function(script, mainParameters, options, call
     try {
       f = new Function(src);
     } catch(e) {
-      this.setError(i+": "+e.message);
+      throw new Error(i+':'+e.message);
     }
   }
   var workerscript = "//ASYNC\n";
@@ -1381,6 +1378,7 @@ OpenJsCad.Processor.prototype = {
         if(e.stack) {
           errtxt += '\nStack trace:\n'+e.stack;
         } 
+        that.setError(errtxt);
         that.statusspan.innerHTML = "Error.";
         that.state = 3; // incomplete
       }

--- a/openjscad.js
+++ b/openjscad.js
@@ -737,6 +737,7 @@ OpenJsCad.parseJsCadScriptASync = function(script, mainParameters, options, call
   workerscript += "var _includePath=" + JSON.stringify(_includePath)+";\n";    //        ''            ''
   workerscript += "var gMemFs = [];\n";
   var ignoreInclude = false;
+  //console.log("SCRIPT ["+workerscript+"]");
   var mainFile;
   for(var fn in gMemFs) {
     workerscript += "// "+gMemFs[fn].name+":\n";
@@ -807,6 +808,7 @@ OpenJsCad.parseJsCadScriptASync = function(script, mainParameters, options, call
     workerscript += "function include(fn) { eval(gMemFs[fn]); }\n";
   }
   //workerscript += "function includePath(p) { _includePath = p; }\n";
+  //console.log("SCRIPT ["+workerscript+"]");
   var blobURL = OpenJsCad.textToBlobUrl(workerscript);
   
   if(!window.Worker) throw new Error("Your browser doesn't support Web Workers. Please try the Chrome or Firefox browser instead.");
@@ -900,24 +902,35 @@ OpenJsCad.FileSystemApiErrorHandler = function(fileError, operation) {
   throw new Error(errtxt);
 };
 
+// Call this routine to install a handler for uncaught exceptions
 OpenJsCad.AlertUserOfUncaughtExceptions = function() {
   window.onerror = function(message, url, line) {
+    var msg = "uncaught exception";
     switch (arguments.length) {
       case 1: // message
-        console.log(arguments[0]);
+        msg = arguments[0];
         break;
       case 2: // message and url
-        console.log(arguments[0]+'\n('+arguments[1]+')');
+        msg = arguments[0]+'\n('+arguments[1]+')';
         break;
       case 3: // message and url and line#
-        console.log(arguments[0]+'\nLine: '+arguments[2]+'\n('+arguments[1]+')');
+        msg = arguments[0]+'\nLine: '+arguments[2]+'\n('+arguments[1]+')';
         break;
       case 4: // message and url and line# and column#
       case 5: // message and url and line# and column# and Error
-        console.log(arguments[0]+'\nLine: '+arguments[2]+',col: '+arguments[3]+'\n('+arguments[1]+')');
+        msg = arguments[0]+'\nLine: '+arguments[2]+',col: '+arguments[3]+'\n('+arguments[1]+')';
         break;
       default:
-        console.log("uncaught exception");
+        break;
+    }
+    if(typeof document !== 'undefined') {
+      var e = document.getElementById("errordiv");
+      if (e !== null) {
+        e.firstChild.textContent = msg;
+        e.style.display = "block";
+      }
+    } else {
+      console.log(msg);
     }
     return false;
   };

--- a/style.css
+++ b/style.css
@@ -130,10 +130,6 @@ canvas {
    vertical-align: middle;
 }
 
-.support {
-   vertical-align: bottom;
-}
-
 #menu, #menu nav a {
    transition: all 0.4s;
    -o-transition: all 0.4s;
@@ -238,10 +234,6 @@ canvas {
    color: #666;
 }
 
-.externalLink {
-   vertical-align: middle;
-}
-
 #examples {
    /* width: 60em; */
    width: auto;
@@ -261,16 +253,6 @@ canvas {
 
 #examples li {
    list-style-type: none;
-}
-
-#examplesList { 
-   border-bottom: 1px solid #888;
-   height: 4px;
-   overflow: hidden;
-}
-
-#examplesList:hover {
-   /*height: 100%;*/
 }
 
 #examplesHandle {


### PR DESCRIPTION
These changes separate the JavaScript from the HTML, and create manageable pieces for the page, the editor, the drag-and-drop, etc. This will help to create further pages as well as extend functionality.

@richievos was a great inspiration, and many of his changes were bundled into these.

This is fully tested off-line, on-line, and CLI. In addition, testing was performed with Firefox, Chrome, Safari, and Opera on Mac OSX.