### PR TITLE
Enhanced Determination of "main" Source

### DIFF
--- a/examples/balloons.jscad
+++ b/examples/balloons.jscad
@@ -11,8 +11,8 @@ function getParameterDefinitions() {
     { name: 'color', type: 'color', initial: '#FFB431', caption: 'Color?' }, 
     { name: 'count', type: 'slider', initial: 3, min: 2, max: 10, step: 1, caption: 'How many?' }, 
     { name: 'friend', type: 'group', caption: 'Friend' }, 
-    { name: 'name', type: 'text', size: 20, maxLength: 20, caption: 'Name?', placeholder: '20 characters' }, 
-    { name: 'date',  type: 'date', min: '1915-01-01', max: '2015-12-31', caption: 'Birthday?', placeholder: 'YYYY-MM-DD' }, 
+    { name: 'name', type: 'text', initial: '', size: 20, maxLength: 20, caption: 'Name?', placeholder: '20 characters' }, 
+    { name: 'date',  type: 'date', initial: '', min: '1915-01-01', max: '2015-12-31', caption: 'Birthday?', placeholder: 'YYYY-MM-DD' }, 
     { name: 'age', type: 'int', initial: 20, min: 1, max: 100, step: 1, caption: 'Age?' }, 
     ]; 
 } 


### PR DESCRIPTION
@xosos opened an issue #106 against drag and drop, as he wasn't able to drop multiple files. The issue was with the determination of the "main" source, which was required to reside in a file named "main.jscad" or "main.js". I enhanced the logic to search for the function declaration in the files if necessary.

Should "main.scad" be allowed as well?

I also removed the hide and show of the editor pane as well. I don't think this is necessary, and showing the "main" source seems more proper to me.

I commented out the debug statements, but left those in the source.

There's a small change to the balloon example as well, adding initial values for name and data parameters. This allows the CLI script to run the example as well.