### PR TITLE
Reworked JSCAD Script Processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@ Todo:
     <script src="formats.js?0.3.1.3"></script>
     <script src="openjscad.js?0.3.1.3"></script>
     <script src="js/jscad-worker.js" charset="utf-8"></script>
+    <script src="js/jscad-function.js" charset="utf-8"></script>
     <script src="openscad.js?0.3.1.3"></script>
     <script src="underscore.js"></script>
     <script src="openscad-openjscad-translator.js"></script>

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@ Todo:
     <script src="csg.js?0.3.1.3"></script>
     <script src="formats.js?0.3.1.3"></script>
     <script src="openjscad.js?0.3.1.3"></script>
+    <script src="js/jscad-worker.js" charset="utf-8"></script>
     <script src="openscad.js?0.3.1.3"></script>
     <script src="underscore.js"></script>
     <script src="openscad-openjscad-translator.js"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -274,8 +274,6 @@ function createOptions() {
 
 var gProcessor = null;
 
-var _includePath = './';
-
 $(document).ready(function() {
     // Show all exceptions to the user:
     OpenJsCad.AlertUserOfUncaughtExceptions();

--- a/js/jscad-function.js
+++ b/js/jscad-function.js
@@ -1,0 +1,67 @@
+// Create an function for processing the JSCAD script into CSG/CAG objects
+//
+// fullurl  - URL to original script
+// script   - FULL script with all possible support routines, etc
+// callback - function to call, returning results or errors
+//
+// This function creates an anonymous Function, which is invoked to execute the thread.
+// The function executes in the GLOBAL context, so all necessary parameters are provided.
+//
+function createJscadFunction(fullurl, script, callback) {
+  //console.log("createJscadFunction()");
+
+// determine the relative base path for include(<relativepath>)
+  var relpath = fullurl;
+  if (relpath.lastIndexOf('/') >= 0) {
+    relpath = relpath.substring(0,relpath.lastIndexOf('/')+1);
+  }
+
+  var source = "// SYNC WORKER\n";
+  source += '  var relpath = "'+relpath+'";\n'
+  source += '  var include = includeJscadSync;\n';
+  source += '\n';
+  source += includeJscadSync.toString()+'\n';
+  source += '\n';
+  source += script+'\n';
+  source += '\n';
+  source += "return main(params);\n";
+
+  //console.log("SOURCE: "+source);
+
+  var f = new Function("params", source);
+  return f;
+};
+
+//
+// THESE FUNCTIONS ARE SERIALIZED FOR INCLUSION IN THE FULL SCRIPT
+//
+// TODO It might be possible to cache the serialized versions
+//
+
+// Include the requested script via MemFs (if available) or HTTP Request
+//
+// (Note: This function is appended together with the JSCAD script)
+//
+function includeJscadSync(fn) {
+// include the requested script via MemFs if possible
+  if (typeof(gMemFs) == 'object') {
+    for(var fs in gMemFs) {
+      if (gMemFs[fs].name == fn) {
+        eval(gMemFs[fs].source);
+        return;
+      }
+    }
+  }
+// include the requested script via webserver access
+// TODO check for FULL URL and use directly
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET',relpath+fn,false);
+  xhr.onload = function() {
+    var src = this.responseText;
+    eval(src);
+  };
+  xhr.onerror = function() {
+  };
+  xhr.send();
+};
+

--- a/js/jscad-function.js
+++ b/js/jscad-function.js
@@ -53,9 +53,12 @@ function includeJscadSync(fn) {
     }
   }
 // include the requested script via webserver access
-// TODO check for FULL URL and use directly
   var xhr = new XMLHttpRequest();
-  xhr.open('GET',relpath+fn,false);
+  var url = relpath+fn;
+  if (fn.match(/^(https:|http:)/i)) {
+    url = fn;
+  }
+  xhr.open('GET',url,false);
   xhr.onload = function() {
     var src = this.responseText;
     eval(src);

--- a/js/jscad-worker.js
+++ b/js/jscad-worker.js
@@ -97,8 +97,10 @@ function includeJscad(fn) {
     }
   }
 // include the requested script via importScripts
-// TODO check for FULL URL and use directly
-  if (self.relpath) fn = self.relpath + fn;
+  var url = self.relpath+fn;
+  if (fn.match(/^(https:|http:)/i)) {
+    url = fn;
+  }
   importScripts(fn);
   return true;
 };

--- a/js/jscad-worker.js
+++ b/js/jscad-worker.js
@@ -14,7 +14,7 @@ function createJscadWorker(fullurl, script, callback) {
   var blobURL = OpenJsCad.textToBlobUrl(source);
   var w = new Worker(blobURL);
 
-  console.log("createJscadWorker: "+source);
+  //console.log("createJscadWorker: "+source);
 
 // when the worker finishes
 // - call back the provided function with the results
@@ -67,8 +67,6 @@ function buildJscadWorkerScript(fullpath, fullscript) {
   source += '  self.relpath = "'+relpath+'";\n';
   source += '\n';
   source += fullscript+'\n';
-  source += includeJscadMemFs.toString()+'\n';
-  source += includeJscadUrl.toString()+'\n';
   source += includeJscad.toString()+'\n';
   source += runJscadWorker.toString()+'\n';
   source += '  runJscadWorker(e);\n';
@@ -101,7 +99,7 @@ function includeJscad(fn) {
   if (fn.match(/^(https:|http:)/i)) {
     url = fn;
   }
-  importScripts(fn);
+  importScripts(url);
   return true;
 };
 

--- a/js/jscad-worker.js
+++ b/js/jscad-worker.js
@@ -1,0 +1,178 @@
+// Create an worker (thread) for processing the JSCAD script into CSG/CAG objects
+//
+// fullurl  - URL to original script
+// script   - FULL script with all possible support routines, etc
+// callback - function to call, returning results or errors
+//
+// This function builds the Worker thread, which is started by a message
+// The Worker thread (below) executes, and returns the results via another message.
+//   (KIND OF LAME but that keeps the scope of variables and functions clean)
+// Upon receiving the message, the callback routine is called with the results
+//
+function createJscadWorker(fullurl, script, callback) {
+console.log("createJscadWorker()");
+
+  var source = buildJscadWorkerScript(fullurl, script);
+  console.log("SOURCE ["+source+"]");
+
+  var blobURL = OpenJsCad.textToBlobUrl(source);
+  var w = new Worker(blobURL);
+
+// when the worker finishes
+// - call back the provided function with the results
+  w.onmessage = function(e) {
+    if (e.data instanceof Object) {
+      var data = e.data;
+      if(data.cmd == 'rendered') {
+        if (data.objects && data.objects.length) {
+        // convert the compact formats back to CSG/CAG form
+          var objects = [];
+          for(var i=0; i<data.objects.length; i++) {
+            var o = data.objects[i];
+            if (o['class'] == 'CSG') { objects.push(CSG.fromCompactBinary(o)); }
+            if (o['class'] == 'CAG') { objects.push(CAG.fromCompactBinary(o)); }
+          }
+          callback(null, objects);
+        } else {
+          throw new Error("JSCAD Worker: missing 'objects'");
+        }
+      } else if(data.cmd == "error") {
+        callback(data.err, null);
+      } else if(data.cmd == "log") {
+        callback(data.txt, null);
+      }
+    }
+  };
+// when there is an error
+// - call back the provided function with the error
+  w.onerror = function(e) {
+    var errtxt = "Error in line "+e.lineno+": "+e.message;
+    callback(errtxt, null);
+  };
+
+  return w;
+};
+
+// Build the Worker script from the parts
+//   fullpath   - URL to the original file
+//   fullscript - full JSCAD script
+// Note: The full script must be define all data and functions required
+function buildJscadWorkerScript(fullpath, fullscript) {
+console.log("buildJscadWorker("+fullpath+")");
+// determine the relative base path for include(<relativepath>)
+  var relpath = fullpath;
+  if (relpath.lastIndexOf('/') >= 0) {
+    relpath = relpath.substring(0,relpath.lastIndexOf('/')+1);
+  }
+  var source = "";
+  source += 'onmessage = function(e) {\n';
+  source += '  include = includeJscad;\n';
+  source += '  self.relpath = "'+relpath+'";\n';
+  source += '\n';
+  source += fullscript+'\n';
+  source += includeJscadMemFs.toString()+'\n';
+  source += includeJscadUrl.toString()+'\n';
+  source += includeJscad.toString()+'\n';
+  source += runJscadWorker.toString()+'\n';
+  source += '  runJscadWorker(e);\n';
+  source += '};';
+  return source;
+}
+
+//
+// THESE FUNCTIONS ARE SERIALIZED FOR INCLUSION IN THE FULL SCRIPT
+//
+// TODO It might be possible to cache the serialized versions
+//
+
+// Implement include() generally for all scripts
+//
+// (Note: This function is appended together with the JSCAD script)
+//
+function includeJscad(fn) {
+// TODO it might be possible to support both MemFs and URL together
+  if ((!typeof gMemFs) && gMemFs.length > 0) {
+     includeJscadMemFs(fn);
+  } else {
+     includeJscadUrl(fn)
+  }
+};
+
+// Include the requested script via MemFs
+//
+// (Note: This function is appended together with the JSCAD script)
+//
+function includeJscadMemFs(fn) {
+  for (var i = 0; i < gMemFs.length; i++) {
+    if (gMemFs[i].name == fn) {
+      eval(gMemFs[i].source);
+      return true;
+    }
+  }
+  return false;
+};
+
+// Include the requested script via URL
+//   If the URL is relative then the relative path is prefixed
+//
+// (Note: This function is appended together with the JSCAD script)
+//
+function includeJscadUrl(fn) {
+// TODO check for FULL URL and use directly
+// add relative path if available
+  if (self.relpath) fn = self.relpath + fn;
+  importScripts(fn);
+  return true;
+};
+
+// Run the JSCAD script via main()
+//
+// The message (event) must contain:
+//   data.cmd        - 'render'
+//   data.parameters - the parameter values to pass to main()
+// The message (event) can also supply:
+//   data.libraries  - the libraries (full URLs) to import
+//
+// (Note: This function is appended together with the JSCAD script)
+//
+function runJscadWorker(e) {
+console.log("onmessage()");
+  var r = {cmd: "error", txt: "try again"};
+  if (e.data instanceof Object) {
+    var data = e.data;
+    if(data.cmd == 'render') {
+    // verify the command contents
+      if(!data.parameters) { throw new Error("JSCAD Processor: missing 'parameters'"); }
+    // setup the environment
+      if(data.libraries && data.libraries.length) {
+        data.libraries.map( function(l) { importScripts(l); } );
+      }
+    // setup the script
+      if (typeof(main) == 'function') {
+        var results = main( data.parameters );
+        if (!results.length) { results = [results]; }
+      // convert the results to a compact format for transfer back
+        var objects = [];
+        for(var i=0; i<results.length; i++) {
+          var o = results[i];
+          if (o instanceof CAG || o instanceof CSG) {
+            objects.push(o.toCompactBinary());
+          }
+        }
+      // return the results
+        if (objects.length > 0) {
+          r.cmd = "rendered";
+          r.objects = objects;
+        } else {
+          r.err = 'The JSCAD script must return one or more CSG or CAG solids.';
+        }
+      } else {
+        r.err = 'The JSCAD script must contain a function main() which returns one or more CSG or CAG solids.';
+      }
+    } else {
+      throw new Error('JSCAD Processor: invalid worker command: '+data.cmd);
+    }
+  }
+  postMessage(r);
+};
+

--- a/js/jscad-worker.js
+++ b/js/jscad-worker.js
@@ -10,13 +10,11 @@
 // Upon receiving the message, the callback routine is called with the results
 //
 function createJscadWorker(fullurl, script, callback) {
-console.log("createJscadWorker()");
-
   var source = buildJscadWorkerScript(fullurl, script);
-  console.log("SOURCE ["+source+"]");
-
   var blobURL = OpenJsCad.textToBlobUrl(source);
   var w = new Worker(blobURL);
+
+  console.log("createJscadWorker: "+source);
 
 // when the worker finishes
 // - call back the provided function with the results
@@ -58,7 +56,6 @@ console.log("createJscadWorker()");
 //   fullscript - full JSCAD script
 // Note: The full script must be define all data and functions required
 function buildJscadWorkerScript(fullpath, fullscript) {
-console.log("buildJscadWorker("+fullpath+")");
 // determine the relative base path for include(<relativepath>)
   var relpath = fullpath;
   if (relpath.lastIndexOf('/') >= 0) {
@@ -90,36 +87,17 @@ console.log("buildJscadWorker("+fullpath+")");
 // (Note: This function is appended together with the JSCAD script)
 //
 function includeJscad(fn) {
-// TODO it might be possible to support both MemFs and URL together
-  if ((!typeof gMemFs) && gMemFs.length > 0) {
-     includeJscadMemFs(fn);
-  } else {
-     includeJscadUrl(fn)
-  }
-};
-
-// Include the requested script via MemFs
-//
-// (Note: This function is appended together with the JSCAD script)
-//
-function includeJscadMemFs(fn) {
-  for (var i = 0; i < gMemFs.length; i++) {
-    if (gMemFs[i].name == fn) {
-      eval(gMemFs[i].source);
-      return true;
+// include the requested script via MemFs if possible
+  if (typeof(gMemFs) == 'object') {
+    for (var i = 0; i < gMemFs.length; i++) {
+      if (gMemFs[i].name == fn) {
+        eval(gMemFs[i].source);
+        return;
+      }
     }
   }
-  return false;
-};
-
-// Include the requested script via URL
-//   If the URL is relative then the relative path is prefixed
-//
-// (Note: This function is appended together with the JSCAD script)
-//
-function includeJscadUrl(fn) {
+// include the requested script via importScripts
 // TODO check for FULL URL and use directly
-// add relative path if available
   if (self.relpath) fn = self.relpath + fn;
   importScripts(fn);
   return true;
@@ -136,7 +114,6 @@ function includeJscadUrl(fn) {
 // (Note: This function is appended together with the JSCAD script)
 //
 function runJscadWorker(e) {
-console.log("onmessage()");
   var r = {cmd: "error", txt: "try again"};
   if (e.data instanceof Object) {
     var data = e.data;

--- a/js/ui-drag-drop.js
+++ b/js/ui-drag-drop.js
@@ -104,33 +104,7 @@ function handleFileSelect(evt) {
 };
 
 function errorHandler(e) {
-  var msg = '';
-
-  switch (e.code) {
-    case FileError.QUOTA_EXCEEDED_ERR:
-      msg = 'QUOTA_EXCEEDED_ERR';
-      break;
-    case FileError.NOT_FOUND_ERR:
-      msg = 'NOT_FOUND_ERR';
-      break;
-    case FileError.SECURITY_ERR:
-      msg = 'SECURITY_ERR';
-      break;
-    case FileError.INVALID_MODIFICATION_ERR:
-      msg = 'INVALID_MODIFICATION_ERR';
-      break;
-    case FileError.INVALID_STATE_ERR:
-      msg = 'INVALID_STATE_ERR';
-      break;
-    case FileError.ENCODING_ERR:
-      msg = 'ENCODING_ERR';
-      break;
-    default:
-      msg = 'Unknown Error';
-      break;
-  };
-
-  console.log('Error: ['+e.code+'] '+msg);
+  console.log('File Error: ['+e.name+'] Please check permissions');
 };
 
 // this is the core of the drag'n'drop:
@@ -141,18 +115,19 @@ function walkFileTree(item,path) {
   //console.log("walkFileTree()");
   path = path||"";
   if(item.isFile) {
+    //console.log("walkFileTree File: "+item.name);
     item.file(function(file) {                // this is also asynchronous ... (making everything complicate)
-      if(file.name.match(/\.(jscad|js|scad|obj|stl|amf|gcode)$/)) {   // FIXME now all files OpenJSCAD can handle
+      if(file.name.match(/\.(jscad|js|scad|obj|stl|amf|gcode)$/i)) {   // FIXME now all files OpenJSCAD can handle
         gMemFsTotal++;
         gCurrentFiles.push(file);
         readFileAsync(file);
       }
     }, errorHandler);
   } else if(item.isDirectory) {
+    //console.log("walkFileTree Directory: "+item.name);
     var dirReader = item.createReader();
-    //console.log("walkFileTree Folder: "+item.name);
     dirReader.readEntries(function(entries) {
-      // console.log("===",entries,entries.length);
+      //console.log("===",entries,entries.length);
       for(var i=0; i<entries.length; i++) {
         //console.log(i,entries[i]);
         walkFileTree(entries[i],path+item.name+"/");

--- a/js/ui-drag-drop.js
+++ b/js/ui-drag-drop.js
@@ -301,18 +301,6 @@ function saveScript(filename,source) {
   gMemFs[filename] = f;
 }
 
-function convertMemFsJson() {
-  var s = '[';
-  var comma = '';
-  for(var fn in gMemFs) {
-    s += comma;
-    s += JSON.stringify(gMemFs[fn]);
-    comma = ',';
-  }
-  s += ']';
-  return s;
-}
-
 // parse the file (and convert) to a renderable source (jscad)
 function parseFile(f, onlyifchanged) {
   //console.log("parseFile("+f.name+")");

--- a/min.html
+++ b/min.html
@@ -11,6 +11,7 @@
   <script src="formats.js"></script>
   <script src="openjscad.js"></script>
   <script src="openscad.js"></script>
+  <script src="js/jscad-worker.js" charset="utf-8"></script>
   <link rel="stylesheet" href="min.css" type="text/css">
 </head>
 
@@ -38,8 +39,6 @@
 <!-- define the design and the parameters -->
   <script type="text/javascript">
     var gProcessor = null;        // required by OpenJScad.org
-    var gMemFs = [];              // required by OpenJScad.org
-    var _includePath = './';      // required by OpenJScad.org
 
     var gComponents = [ { file: 'examples/logo.jscad' } ];
 

--- a/openjscad.js
+++ b/openjscad.js
@@ -999,30 +999,31 @@ OpenJsCad.Processor = function(containerdiv, onchange) {
   this.state = 0; // initialized
 };
 
-OpenJsCad.Processor.convertToSolid = function(obj) {
-  //echo("typeof="+typeof(obj),obj.length);
+OpenJsCad.Processor.convertToSolid = function(objs) {
+  echo("convertToSolid: typeof="+typeof(objs));
 
-  if( (typeof(obj) == "object") && ((obj instanceof CAG)) ) {
-    // convert a 2D shape to a thin solid:
-    obj = obj.extrude({offset: [0,0,0.1]});
-
-  } else if( (typeof(obj) == "object") && ((obj instanceof CSG)) ) {
-    // obj already is a solid, nothing to do
-    ;
-
-  } else if(obj.length) {                   // main() return an array, we consider it a bunch of CSG not intersecting
-    //echo("putting them together");
-    var o = obj[0];
-    for(var i=1; i<obj.length; i++) {
-      o = o.unionForNonIntersecting(obj[i]);
+  if (objs.length === undefined) {
+    if ((objs instanceof CAG) || (objs instanceof CSG)) {
+      var obj = objs;
+      objs = [obj];
+    } else {
+      throw new Error("Cannot convert object ("+typeof(objs)+") to solid");
     }
-    obj = o;
-    //echo("done.");
-
-  } else {
-    throw new Error("Cannot convert to solid");
   }
-  return obj;
+
+  var solid = null;
+  for(var i=0; i<objs.length; i++) {
+    var obj = objs[i];
+    if (obj instanceof CAG) {
+      obj = obj.extrude({offset: [0,0,0.1]}); // convert CAG to a thin solid CSG
+    }
+    if (solid !== null) {
+      solid = solid.unionForNonIntersecting(obj);
+    } else {
+      solid = obj;
+    }
+  }
+  return solid;
 };
 
 OpenJsCad.Processor.prototype = {
@@ -1168,13 +1169,13 @@ OpenJsCad.Processor.prototype = {
     this.clearViewer();
   },
 
-  setCurrentObject: function(obj) {
-    this.currentObject = obj;                                  // CAG or CSG
+  setCurrentObject: function(objs) {
+    this.currentObject = objs;                                  // CAG or CSG
     if(this.viewer) {
-      var csg = OpenJsCad.Processor.convertToSolid(obj);       // enfore CSG to display
+      var csg = OpenJsCad.Processor.convertToSolid(objs);       // enfore CSG to display
       this.viewer.setCsg(csg);
       this.viewer.state = 2;
-      if(obj.length)             // if it was an array (multiple CSG is now one CSG), we have to reassign currentObject
+      if(objs.length)             // if it was an array (multiple CSG is now one CSG), we have to reassign currentObject
          this.currentObject = csg;
     }
 
@@ -1337,7 +1338,84 @@ OpenJsCad.Processor.prototype = {
     return paramValues;
   },
 
+  getFullScript: function()
+  {
+    var script = "";
+  // add the file cache
+    script += 'var gMemFs = [';
+    if (!typeof gMemFs) {
+      var comma = '';
+      for(var fn in gMemFs) {
+        s += comma;
+        s += JSON.stringify(gMemFs[fn]);
+        comma = ',';
+      }
+    }
+    script += '];\n';
+    script += '\n';
+  // add the main script
+    script += this.script;
+    return script;
+  },
+
+  rebuildSolidAsync: function()
+  {
+  console.log("rebuildSolidAsync");
+    var parameters = this.getParamValues();
+    var script     = this.getFullScript();
+
+    if(!window.Worker) throw new Error("Worker threads are unsupported.");
+
+  // create the worker
+    var that = this;
+    that.state = 1; // processing
+    that.worker = createJscadWorker( this.baseurl+this.filename, script,
+    // handle the results
+      function(err, objs) {
+        console.log("callback");
+        that.worker = null;
+        if(err) {
+          that.setError(err);
+          that.statusspan.innerHTML = "Error.";
+          that.state = 3; // incomplete
+        } else {
+          that.setCurrentObject(objs);
+          that.statusspan.innerHTML = "Ready.";
+          that.state = 2; // complete
+        }
+        that.enableItems();
+        if(that.onchange) that.onchange();
+      }
+    );
+  // FIXME this list should come from the Processor
+    var libraries = [
+      this.baseurl+"csg.js",
+      this.baseurl+"formats.js",
+      this.baseurl+"openjscad.js",
+      this.baseurl+"openscad.js"
+    ];
+  // start the worker
+    that.worker.postMessage({cmd: "render", parameters: parameters, libraries: libraries});
+  },
+
   rebuildSolid: function()
+  {
+  // clear previous solid and settings
+    this.abort();
+    this.setError("");
+    this.clearViewer();
+    this.enableItems();
+    this.statusspan.innerHTML = "Rendering. Please wait <img id=busy src='imgs/busy.gif'>";
+  // rebuild the solid
+    try {
+      this.rebuildSolidAsync();
+    } catch(e) {
+      console.log("async failed, try sync compute, error: "+e.message);
+    // TODO rebuild sync
+    }
+  },
+
+  rebuildSolidOld: function()
   {
     this.abort();
     this.setError("");
@@ -1525,6 +1603,7 @@ OpenJsCad.Processor.prototype = {
 
   generateOutputFileBlobUrl: function() {
     if (OpenJsCad.isSafari()) {
+console.log("Trying download via DATA URI");
     // convert BLOB to DATA URI
       var blob = this.currentObjectToBlob();
       var that = this;
@@ -1543,6 +1622,8 @@ OpenJsCad.Processor.prototype = {
       };
       reader.readAsDataURL(blob);
     } else {
+console.log("Trying download via BLOB URL");
+    // convert BLOB to BLOB URL (HTML5 Standard)
       var blob = this.currentObjectToBlob();
       var windowURL=OpenJsCad.getWindowURL();
       this.outputFileBlobUrl = windowURL.createObjectURL(blob);
@@ -1562,6 +1643,7 @@ OpenJsCad.Processor.prototype = {
     if(!request) {
       throw new Error("Your browser does not support the HTML5 FileSystem API. Please try the Chrome browser instead.");
     }
+console.log("Trying download via FileSystem API");
     // create a random directory name:
     var extension = this.selectedFormatInfo().extension;
     var dirname = "OpenJsCadOutput1_"+parseInt(Math.random()*1000000000, 10)+"."+extension;


### PR DESCRIPTION
This is a fairly significant change, moving away from code within comments within code. The functionality is now split into jscad-worker.js (ASYNC) and jscad-function.js (SYNC). The code can now be fixed/debugged easily, and enhanced if additional functionality is required.

Note: The old async and sync functions still exist, and should be removed once the new code has been tested completely.

In addition, there are a few small changes to drag and drop to accommodate and streamline processing.

Finally, the strange global variable _includePath is now derived from the URL of script. This global is no longer required. 