### PR TITLE
Updating Master to Fix Issues with URL Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For CLI (command-line interface) rendering install <a href="http://nodejs.org/">
 
 <h2>History</h2>
 <ul>
-<li>2016/02/02: 0.4.0: refactored, functionality split up into more files, mostly done by Z3 Dev
+<li>2016/02/25: 0.4.0: refactored, functionality split up into more files, mostly done by Z3 Dev
 <li>2015/10/23: 0.3.1: including new parameter options by Z3 Dev
 <li>2015/07/02: 0.3.0: format.js (Stefan Baumann), and Blob.js/openjscad improved by Z3 Dev
 <li>2015/05/20: 0.2.4: renumbering, latest csg.js from http://joostn.github.com/OpenJsCad/ adapted

--- a/openjscad.js
+++ b/openjscad.js
@@ -986,6 +986,8 @@ OpenJsCad.Processor = function(containerdiv, onchange) {
   this.options = {};
   this.createElements();
   this.baseurl = document.location.href;
+  this.baseurl = this.baseurl.replace(/#.*$/,''); // remove remote URL
+  this.baseurl = this.baseurl.replace(/\?.*$/,''); // remove parameters
   if (this.baseurl.lastIndexOf('/') != (this.baseurl.length-1)) {
     this.baseurl = this.baseurl.substring(0,this.baseurl.lastIndexOf('/')+1);
   }

--- a/openjscad.js
+++ b/openjscad.js
@@ -2,7 +2,7 @@
 //   few adjustments by Rene K. Mueller <spiritdude@gmail.com> for OpenJSCAD.org
 //
 // History:
-// 2016/02/02: 0.4.0: GUI refactored, functionality split up into more files, mostly done by Z3 Dev
+// 2016/02/25: 0.4.0: GUI refactored, functionality split up into more files, mostly done by Z3 Dev
 // 2013/03/12: reenable webgui parameters to fit in current design
 // 2013/03/11: few changes to fit design of http://openjscad.org
 


### PR DESCRIPTION
This is the fix and update to the 0.4.0 release. Contents include:
-  Remove remote links and parameters before setting baseurl 
- Date change only