### PR TITLE
Changes to support various HTML pages

### DIFF
--- a/min.html
+++ b/min.html
@@ -23,6 +23,7 @@ History:
   <script src="openjscad.js?0.4.0"></script>
   <script src="openscad.js?0.4.0"></script>
   <script src="js/jscad-worker.js?0.4.0" charset="utf-8"></script>
+  <script src="js/jscad-function.js?0.4.0" charset="utf-8"></script>
   <link rel="stylesheet" href="min.css?0.4.0" type="text/css">
 </head>
 
@@ -67,7 +68,7 @@ History:
 
       xhr.onload = function() {
         var source = this.responseText;
-        console.log(source);
+        //console.log(source);
 
         if(filepath.match(/\.jscad$/i)||filepath.match(/\.js$/i)) {
           gProcessor.setStatus("Processing "+filepath+" <img id=busy src='imgs/busy.gif'>");

--- a/openjscad.css
+++ b/openjscad.css
@@ -81,7 +81,13 @@ canvas {
   
   /* cursor: move;     moveable now */
 }
+#parametersdiv th {
+  text-align: left;
+  font-size: 1em;
+  font-weight: bold;
+}
 #parametersdiv td {
+  text-align: right;
   font-size: 0.8em;
 }
 #parametersdiv input, #parametersdiv textarea, #parametersdiv select {
@@ -90,17 +96,18 @@ canvas {
   border: none;
 }
 
-#parametersdiv .caption {
-   text-align: right;
-}
-
 #instantUpdate {
    margin-left: 1em;
 }
-
 #instantUpdateLabel {
    font-size: 0.9em;
 }
 
-.statusdiv {
+#statusdiv {
+}
+#statusspan {
+   margin-right: 2em;
+}
+#statusbuttons {
+   float: right;
 }

--- a/openjscad.js
+++ b/openjscad.js
@@ -896,6 +896,7 @@ OpenJsCad.Processor.prototype = {
     {
       this.containerdiv.removeChild(0);
     }
+
     var viewerdiv = document.createElement("div");
     viewerdiv.className = "viewer";
     viewerdiv.style.width = '100%';
@@ -939,18 +940,26 @@ OpenJsCad.Processor.prototype = {
 
       //end of zoom control
     }
-    //this.errordiv = document.createElement("div");
-    this.errordiv = document.getElementById("errordiv");
+
+    this.errordiv = this.containerdiv.parentElement.querySelector("div#errordiv");
+    if (!this.errordiv) {
+      this.errordiv = document.createElement("div");
+      this.errordiv.id = 'errordiv';
+      this.containerdiv.parentElement.appendChild(this.errordiv);
+    }
     this.errorpre = document.createElement("pre");
     this.errordiv.appendChild(this.errorpre);
-    //this.statusdiv = document.createElement("div");
-    this.statusdiv = document.getElementById("statusdiv");
-    this.statusdiv.className = "statusdiv";
+
+    this.statusdiv = this.containerdiv.parentElement.querySelector("div#statusdiv");
+    if (!this.statusdiv) {
+      this.statusdiv = document.createElement("div");
+      this.statusdiv.id = "statusdiv";
+      this.containerdiv.parentElement.appendChild(this.statusdiv);
+    }
     this.statusspan = document.createElement("span");
     this.statusspan.id = 'statusspan';
-    this.statusspan.style.marginRight = '2em';
     this.statusbuttons = document.createElement("span");
-    this.statusbuttons.style.float = "right";
+    this.statusbuttons.id = 'statusbuttons';
     this.statusdiv.appendChild(this.statusspan);
     this.statusdiv.appendChild(this.statusbuttons);
     this.abortbutton = document.createElement("button");
@@ -974,16 +983,17 @@ OpenJsCad.Processor.prototype = {
     this.downloadOutputFileLink.className = "downloadOutputFileLink"; // so we can css it
     this.statusbuttons.appendChild(this.downloadOutputFileLink);
 
-    //this.parametersdiv = document.createElement("div");            // already created
-    this.parametersdiv = document.getElementById("parametersdiv");   // get the info
-    this.parametersdiv.id = "parametersdiv";
-    // this.parametersdiv.className = "ui-draggable";                   // via jQuery draggable() but it screws up
-
+    this.parametersdiv = this.containerdiv.parentElement.querySelector("div#parametersdiv");
+    if (!this.parametersdiv) {
+      this.parametersdiv = document.createElement("div");
+      this.parametersdiv.id = "parametersdiv";
+      this.containerdiv.parentElement.appendChild(this.parametersdiv);
+    }
     this.parameterstable = document.createElement("table");
     this.parameterstable.className = "parameterstable";
     this.parametersdiv.appendChild(this.parameterstable);
 
-    var element = document.getElementById("updateButton");
+    var element = this.parametersdiv.querySelector("button#updateButton");
     if (element === null) {
       element = document.createElement("button");
       element.innerHTML = "Update";
@@ -1010,11 +1020,6 @@ OpenJsCad.Processor.prototype = {
     this.parametersdiv.appendChild(element);
 
     this.enableItems();
-
-    // they exist already, so no appendChild anymore (remains here)
-    //this.containerdiv.appendChild(this.statusdiv);
-    //this.containerdiv.appendChild(this.errordiv);
-    //this.containerdiv.appendChild(this.parametersdiv);
 
     this.clearViewer();
   },


### PR DESCRIPTION
These changes were made to allow more flexibility in the layout and the styles of HTML pages. The hard coded styles were moved to the openjscad.css file. The DIV elements for errors, status, and parameters are created if not found.

Functionally, there should be no difference. All examples pass, as well as drag and drop.