### PR TITLE
Source editor workflow improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ Todo:
         <div id="menuVersion">Version <script>document.write(OpenJsCad.version);</script></div>
         <p/>
         <table class="info">
-          <tr><td align="right" class="infoOperation">Render Code</td><td class="infoKey">F5 (Within Editor)</td></tr>
+          <tr><td align="right" class="infoOperation">Render Code</td><td class="infoKey">F5 or Shift + Return (Within Editor)</td></tr>
           <tr><td align="right" class="infoOperation">Save To Cache</td><td class="infoKey">CTRL + S (Within Editor)</td></tr>
           <tr><td align="right" class="infoOperation">Load From Cache</td><td class="infoKey">CTRL + L (Within Editor)</td></tr>
           <tr><td align="right" class="infoOperation">Download Code</td><td class="infoKey">CTRL + SHIFT + S (Within Editor)</td></tr>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,10 @@ Todo:
         <div id="menuVersion">Version <script>document.write(OpenJsCad.version);</script></div>
         <p/>
         <table class="info">
-          <tr><td align="right" class="infoOperation">Render Code</td><td class="infoKey">SHIFT + RETURN</td></tr>
+          <tr><td align="right" class="infoOperation">Render Code</td><td class="infoKey">F5 (Within Editor)</td></tr>
+          <tr><td align="right" class="infoOperation">Save To Cache</td><td class="infoKey">CTRL + S (Within Editor)</td></tr>
+          <tr><td align="right" class="infoOperation">Load From Cache</td><td class="infoKey">CTRL + L (Within Editor)</td></tr>
+          <tr><td align="right" class="infoOperation">Download Code</td><td class="infoKey">CTRL + SHIFT + S (Within Editor)</td></tr>
           <tr><td align="right" class="infoOperation">Reset View</td><td class="infoKey">CRTL + RETURN</td></tr>
           <tr><td align="right" class="infoOperation">Rotate XZ</td><td class="infoKey">Left Mouse</td></tr>
           <tr><td align="right" class="infoOperation">Pan</td><td class="infoKey">Middle Mouse or SHIFT + Left Mouse</td></tr>

--- a/js/index.js
+++ b/js/index.js
@@ -295,7 +295,12 @@ $(document).ready(function() {
     setupDragDrop();
 
     //gProcessor.setDebugging(debugging);
-    if(me=='web-online') {    // we are online, fetch first example
+    if (me !== 'cli' && localStorage.editorContent && localStorage.editorContent.length) {
+      putSourceInEditor(localStorage.editorContent, "MyDesign.jscad");
+      gProcessor.setJsCad(localStorage.editorContent, "MyDesign.jscad");
+      gProcessor.setStatus('Loaded source from browser storage');
+    } 
+    else if (me=='web-online') {    // we are online, fetch first example
       docUrl = document.URL;
       params = {};
       docTitle = '';

--- a/js/ui-editor.js
+++ b/js/ui-editor.js
@@ -55,7 +55,7 @@ function setUpEditor(divname) {
 // enable special keystrokes
   gEditor.commands.addCommand({
        name: 'setJSCAD',
-       bindKey: { win: 'F5', mac: 'F5' },
+       bindKey: { win: 'F5|Shift-Return', mac: 'F5|Shift-Return' },
        exec: function(editor) {
           var src = editor.getValue();
           if(src.match(/^\/\/\!OpenSCAD/i)) {

--- a/js/ui-editor.js
+++ b/js/ui-editor.js
@@ -55,7 +55,7 @@ function setUpEditor(divname) {
 // enable special keystrokes
   gEditor.commands.addCommand({
        name: 'setJSCAD',
-       bindKey: { win: 'Shift-Return', mac: 'Shift-Return' },
+       bindKey: { win: 'F5', mac: 'F5' },
        exec: function(editor) {
           var src = editor.getValue();
           if(src.match(/^\/\/\!OpenSCAD/i)) {
@@ -68,7 +68,7 @@ function setUpEditor(divname) {
           if (gProcessor !== null) {
             gProcessor.setJsCad(src);
           }
-       },
+       }
     });
   gEditor.commands.addCommand({
        name: 'viewerReset',
@@ -77,7 +77,43 @@ function setUpEditor(divname) {
           if (gProcessor !== null) {
             gProcessor.viewer.reset();
           }
-       },
+       }
+    });
+  gEditor.commands.addCommand({
+       name: 'saveSource',
+       bindKey: { win: 'Ctrl-S', mac: 'Command-S' },
+       exec: function(editor) {
+          var src = editor.getValue();
+          localStorage.editorContent = src;
+          gProcessor.setStatus('Saved source to browser storage');
+       }
+    });
+  gEditor.commands.addCommand({
+       name: 'loadSource',
+       bindKey: { win: 'Ctrl-L', mac: 'Command-L' },
+       exec: function(editor) {
+          var src = localStorage.editorContent;
+          src && src.length ? editor.setValue(src, 1) : null;
+          gEditor.commands.exec('setJSCAD', editor);
+          gProcessor.setStatus('Loaded source from browser storage');
+       }
+    });
+  gEditor.commands.addCommand({
+       name: 'downloadSource',
+       bindKey: { win: 'Ctrl-Shift-S', mac: 'Command-Shift-S' },
+       exec: function(editor) {
+          var src = editor.getValue();
+          setTimeout(function(){
+            var blob = new Blob([src], {type : 'text/plain'});
+            var object_url = URL.createObjectURL(blob);
+            var save_link = document.createElementNS("http://www.w3.org/1999/xhtml", "a");
+            save_link.href = object_url;
+            save_link.download = 'MyDesign.jscad';
+            
+            var event = new MouseEvent('click');
+            save_link.dispatchEvent(event);
+          },0);
+       }
     });
 }
 


### PR DESCRIPTION
I have been using the live version of OpenJSCAD.org for a number of weeks now and repeatedly refreshed the page when intending to build / render. I also found it lengthy to repeatedly copy & paste my code in to and out of another editor in order to save.

This pull request adds the following features to the editor on the site:
 - Save to and load from local storage (CTRL-S, CTRL-L)
 - Download the source as a file **MyDesign.jscad** (CTRL-SHIFT-S)
 - Automatically resume editing from previously saved source in local storage when visiting the page
 - Update render shortcut to F5 and add mentioned shortcuts above

If there are any suggestions to improve these features, please let me know!