### PR TITLE
fix `make deinstall` to properly deinstall openjscad

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,9 @@ install::
 	mkdir -p cache; chmod a+rw cache
                                 
 deinstall::
-	sudo rm -rf ${NODE_MODULES}/openscad-openjscad-translator
-	sudo rm -f ${LIB}/*.js 
+	sudo rm -rf ${NODE_MODULES}openscad-openjscad-translator
+	sudo rm /usr/local/bin/openjscad
+	sudo rm -rf ${LIB}
 
 tests::
 	openjscad examples/logo.jscad


### PR DESCRIPTION
Pretty small fix, that makes `make deinstall` actually deinstall the bin and the directory that was created on `make install`.

Nothing too major but good hygiene for any project.