### PR TITLE
Add additional check for `lib` in format.js module require section.  …

### DIFF
--- a/formats.js
+++ b/formats.js
@@ -9,7 +9,7 @@ Copyright (c) 2011 Evan Wallace (http://evanw.github.com/csg.js/)
 Copyright (c) 2012 Alexandre Girard (https://github.com/alx)
 
 Exporting CSG into various formats:
-   - AMF 
+   - AMF
    - X3D
    - STL (ASCII & Binary)
 Exporting CAG into various formats:
@@ -22,7 +22,7 @@ License: MIT license
 
 // import the required modules if necessary
 
-if(typeof module !== 'undefined') {    // used via nodejs
+if(typeof module !== 'undefined' && typeof lib !== 'undefined') {    // used via nodejs
     CSG = require(lib+'csg.js').CSG;
     CAG = require(lib+'csg.js').CAG;
     Blob = require(lib+'Blob.js').Blob;
@@ -484,4 +484,3 @@ CAG.prototype.toSvg = function() {
     module.CSG = CSG;
     module.CAG = CAG;
 })(this);
-


### PR DESCRIPTION
…While running in electron, the node module objects exist, but the global `lib` doesn’t, so the code fails attempting to require in modules.  Checking to see if `lib` exists before requiring in from the `lib` directory solves the electron issue.