### PR TITLE
Add support for include() in remote files; remove  need for proxy.

### DIFF
--- a/src/jscad/processor.js
+++ b/src/jscad/processor.js
@@ -424,7 +424,7 @@ Processor.prototype = {
 
   // script: javascript code
   // filename: optional, the name of the .jscad file
-  setJsCad: function (script, filename) {
+  setJsCad: function (script, filename, includePathBaseUrl) {
     // console.log('setJsCad', script, filename)
     if (!filename) filename = 'openjscad.jscad'
 
@@ -452,6 +452,7 @@ Processor.prototype = {
     if (!scripthaserrors) {
       this.script = script
       this.filename = filename
+      this.includePathBaseUrl = includePathBaseUrl
       this.rebuildSolid()
     } else {
       this.enableItems()
@@ -492,7 +493,7 @@ Processor.prototype = {
     // prepare all parameters
     const parameters = getParamValues(this.paramControls)
     const script = this.getFullScript()
-    const fullurl = this.baseurl + this.filename
+    const fullurl = this.includePathBaseUrl + this.filename
     const options = {memFs: this.memFs}
 
     this.state = 1 // processing

--- a/src/ui/examples.js
+++ b/src/ui/examples.js
@@ -113,13 +113,13 @@ export function fetchExample (filename, url, {memFs, gProcessor, gEditor}) {
         // FIXME: cannot do it from here, bloody globals
         // saveScript(data.filename, data.converted)
       }
-      gProcessor.setJsCad(data.converted, data.filename)
+      gProcessor.setJsCad(data.converted, data.filename, data.baseurl)
     }
   }
 
   if (1) { // doesn't work off-line yet
     var xhr = new XMLHttpRequest()
-    xhr.open('GET', filename, true)
+    xhr.open('GET', url || filename, true)
     if (filename.match(/\.(stl|gcode)$/i)) {
       xhr.overrideMimeType('text/plain; charset=x-user-defined') // our pseudo binary retrieval (works with Chrome)
     }
@@ -127,13 +127,12 @@ export function fetchExample (filename, url, {memFs, gProcessor, gEditor}) {
 
     xhr.onload = function () {
       const source = this.responseText
-      const path = filename
-      const _includePath = path.replace(/\/[^\/]+$/, '/')
+      const baseurl = url ? url.replace(/\/[^\/]+$/, '/') : gProcessor.baseurl
+      const filename = url ? url.replace(/^.+\//, '') : filename
 
       // FIXME: refactor : same code as ui/drag-drop
       gProcessor.setStatus('converting', filename)
       const worker = createConversionWorker(onConversionDone)
-      const baseurl = gProcessor.baseurl
       // NOTE: cache: false is set to allow evaluation of 'include' statements
       worker.postMessage({version, baseurl, source, filename, cache: false})
     }
@@ -166,18 +165,9 @@ export function loadInitialExample (me, params) {
 
     function loadRemote (u, {memFs, gProcessor, gEditor, remoteUrl}) {
       console.log('loadRemote')
-      var xhr = new XMLHttpRequest()
-      xhr.open('GET', remoteUrl + u, true)
-      if (u.match(/\.(stl|gcode)$/i)) {
-        xhr.overrideMimeType('text/plain; charset=x-user-defined') // our pseudo binary retrieval (works with Chrome)
-      }
       gProcessor.setStatus('loading', u)
-      xhr.onload = function () {
-        var data = JSON.parse(this.responseText)
-        fetchExample(data.file, data.url, {memFs, gProcessor, gEditor})
-        document.location = docUrl.replace(/#.*$/, '#') // this won't reload the entire web-page
-      }
-      xhr.send()
+      fetchExample(u.replace(/^.+\//, ''), u, {memFs, gProcessor, gEditor})
+      document.location = docUrl.replace(/#.*$/, '#') // this won't reload the entire web-page
     }
 
     if (isRemote) // remote file referenced, e.g. http://openjscad.org/#http://somewhere/something.ext


### PR DESCRIPTION
Download all files directly (rather than tunneling through a proxy
server) to remove dependence on running a special server. This is
useful, for example, when providing a remote link to a Github repository
for a project that isn't a single file. Remote projects (with includes)
are currently limited to someone running a special server; this ensures
effectively any remote file host is usable instead.

We also store the include file base path separately now since it should
be resolved to the host of the primary file rather than the host serving
up the OpenJSCAD viewer.

This also cleans up the `include` logic a bit: currently regex parsing
is used for replacement which isn't safe: i.e., it's possible for the
regex to match unnecessarily. It's also the case that multiple includes
for the same file can fail since the current logic naively inserts the
included source multiple times. Instead I now ensure that the included
source is only executed once and rather than inline it override the
`include` function to do the work for me. Regex matching of what files
to load is still in place; ideally that'd be replaced as well since
regex parsing isn't safe.